### PR TITLE
Add black default fill, as specified in SVG standard

### DIFF
--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -893,7 +893,18 @@ class TikZPathExporter(inkex.Effect):
                 else:
                     options.append('fill=%s' % self.get_color(fill))
             else:
+                # Shapes are defined as in SVG standard
+                # https://www.w3.org/TR/2011/REC-SVG11-20110816/intro.html#TermShape
+                shapes = ('path', 'rect', 'circle', 'ellipse',
+                    'line', 'polyline', 'polygon')
+                shapes = [_ns(x) for x in shapes]
+
                 if 'fill' in accumulated_state.fill:
+                    options.append('fill')
+                elif node.tag in shapes:
+                    # svg shapes with no fill option should fill by black
+                    # https://www.w3.org/TR/2011/REC-SVG11-20110816/painting.html#FillProperty
+                    # tikz automatically does fill=black if fill is empty
                     options.append('fill')
 
         marker_options = self._handle_markers(state, accumulated_state)


### PR DESCRIPTION
I know this repo is unmaintained, but I thought I'd make this pull request anyway since the fixes were helpful to me, so they could be helpful to others.

This pull request fixes ~three~ one things:

1. ~By @jpstotz, fixes code to work with Python 3. The main error in the code was caused by the removed [`string.strip`](https://docs.python.org/2/library/string.html#string.strip) function, which was replaced by the [`str.strip`](https://docs.python.org/3/library/stdtypes.html#str.strip) function in Python 3.~ No longer needed due to https://github.com/xyz2tex/svg2tikz/commit/099c9c6d72a47d12f1f3c0697739e6cae428e287
2. ~Again by @jpstotz, fixes code to work correctly in Windows (or at least I assume it was broken in Windows, I run Linux), since the Windows terminal does not like Unicode. Shouldn't matter in Python 3.6 or later due to [PEP 528](https://www.python.org/dev/peps/pep-0528/).~ No longer needed due to https://github.com/xyz2tex/svg2tikz/commit/099c9c6d72a47d12f1f3c0697739e6cae428e287
3. In the SVG 1.1 Standard, if the fill property is empty/undefined, its initial value should be `black` [[Link](https://www.w3.org/TR/2011/REC-SVG11-20110816/painting.html#FillProperty)]. This should happen for any shape (ie `path`, `rect`, `circle`, `ellipse`, `line`, `polyline`, `polygon` [[Link](https://www.w3.org/TR/2011/REC-SVG11-20110816/intro.html#TermShape)]). Fixes #32 for me.

_Edit:_ Rebased onto `master` branch to fix merge conflicts. I'm 95% sure this will also fix https://github.com/xyz2tex/svg2tikz/issues/39 too.

