### PR TITLE
Add support for SVG's markers

### DIFF
--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -651,7 +651,7 @@ class TikZPathExporter(inkex.Effect):
         parser = self.OptionParser
         parser.set_defaults(codeoutput='standalone', crop=False, clipboard=False,
                             wrap=True, indent=True, returnstring=False, scale=1,
-                            mode='effect', notext=False, verbose=False, texmode='escape', markings='ignore')
+                            mode='effect', notext=False, verbose=False, texmode='escape')
         parser.add_option('--codeoutput', dest='codeoutput',
                           choices=('standalone', 'codeonly', 'figonly'),
                           help="Amount of boilerplate code (standalone, figonly, codeonly).")
@@ -845,11 +845,12 @@ class TikZPathExporter(inkex.Effect):
 
     def _handle_markers(self, state, accumulated_state):
         # http://www.w3.org/TR/SVG/painting.html#MarkerElement
-        if self.options.markings == 'ignore':
-            return []
+        marker = '-'
         if state.marker_start:
-            if state.marker_start == 'none' and accumulated_state.marker_start:
-                pass
+            marker = '<' + marker
+        if state.marker_end:
+            marker = marker + '>'
+        return [marker];
 
     def convert_svgstate_to_tikz(self, state, accumulated_state=None, node=None):
         """Return a node's SVG styles as a list of TikZ options"""


### PR DESCRIPTION
This commit enables to export path with end/start markers. This is typically to put arrows at the beginning/ending of lines. I do not account for the exact marker though and only put and arrow at the beginning/end. This was helpful for me, but maybe it isn't what you where thinking of doing.