### PR TITLE
Compatible with Inkscape 1.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SVG2TikZ
+# SVG2TikZ (Inkscape 1.x.x compatible)
 
 SVG2TikZ, formally known as Inkscape2TikZ ,are a set of tools for converting SVG graphics to TikZ/PGF code. 
 This project is licensed under the GNU GPL  (see  the [LICENSE](/LICENSE) file).

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -627,7 +627,7 @@ class TikZPathExporter(inkex.Effect):
         self.inkscape_mode = inkscape_mode
         inkex.Effect.__init__(self)
         if not hasattr(self, 'unittouu'):
-            self.unittouu = inkex.unittouu
+            self.svg.unittouu = inkex.unittouu
 
         self._set_up_options()
 
@@ -904,7 +904,7 @@ class TikZPathExporter(inkex.Effect):
         # Fixed in CVS.
         dasharray = state.stroke.get('stroke-dasharray')
         if dasharray and dasharray != 'none':
-            lengths = list(map(self.unittouu, [i.strip() for i in dasharray.split(',')]))
+            lengths = list(map(self.svg.unittouu, [i.strip() for i in dasharray.split(',')]))
             dashes = []
             for idx, length in enumerate(lengths):
                 lenstr = "%0.2fpt" % (length * 0.8 * self.options.scale)
@@ -1029,11 +1029,11 @@ class TikZPathExporter(inkex.Effect):
         # http://www.w3.org/TR/SVG/struct.html#ImageElement
         # http://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute
         #         Convert the pixel values to pt first based on http://www.endmemo.com/sconvert/pixelpoint.php
-        x = self.unittouu(node.get('x', '0'));
-        y = self.unittouu(node.get('y', '0'));
+        x = self.svg.unittouu(node.get('x', '0'));
+        y = self.svg.unittouu(node.get('y', '0'));
 
-        width = self.pxToPt(self.unittouu(node.get('width', '0')));
-        height = self.pxToPt(self.unittouu(node.get('height', '0')));
+        width = self.pxToPt(self.svg.unittouu(node.get('width', '0')));
+        height = self.pxToPt(self.svg.unittouu(node.get('height', '0')));
 
         href = node.get(_ns('href', 'xlink'));
         isvalidhref = 'data:image/png;base64' not in href;
@@ -1087,7 +1087,7 @@ class TikZPathExporter(inkex.Effect):
         elif node.tag in [_ns('polyline'),
                           _ns('polygon')]:
             points = node.get('points', '').replace(',', ' ')
-            points = list(map(self.unittouu, points.split()))
+            points = list(map(self.svg.unittouu, points.split()))
             if node.tag == _ns('polyline'):
                 cmd = 'polyline'
             else:
@@ -1097,15 +1097,15 @@ class TikZPathExporter(inkex.Effect):
         elif node.tag in _ns('line'):
             points = [node.get('x1'), node.get('y1'),
                       node.get('x2'), node.get('y2')]
-            points = list(map(self.unittouu, points))
+            points = list(map(self.svg.unittouu, points))
             # check for zero lenght line
             if not ((points[0] == points[2]) and (points[1] == points[3])):
                 return ('polyline', points), options
 
         if node.tag == _ns('circle'):
             # ugly code...
-            center = list(map(self.unittouu, [node.get('cx', '0'), node.get('cy', '0')]))
-            r = self.unittouu(node.get('r', '0'))
+            center = list(map(self.svg.unittouu, [node.get('cx', '0'), node.get('cy', '0')]))
+            r = self.svg.unittouu(node.get('r', '0'))
             if r > 0.0:
                 return ('circle', self.transform(center) + self.transform([r])), options
 
@@ -1132,8 +1132,8 @@ class TikZPathExporter(inkex.Effect):
         else:
             textstr = escape_texchars(raw_textstr)
 
-        x = self.unittouu(node.get('x', '0'))
-        y = self.unittouu(node.get('y', '0'))
+        x = self.svg.unittouu(node.get('x', '0'))
+        y = self.svg.unittouu(node.get('y', '0'))
         p = [('M', [x, y]), ('TXT', textstr)]
         return p, []
 
@@ -1167,7 +1167,7 @@ class TikZPathExporter(inkex.Effect):
         if node.get('x') or node.get('y'):
             transform = node.get('transform', '')
             transform += ' translate(%s,%s) ' \
-                         % (self.unittouu(node.get('x', 0)), self.unittouu(node.get('y', 0)))
+                         % (self.svg.unittouu(node.get('x', 0)), self.svg.unittouu(node.get('y', 0)))
             use_g.set('transform', transform)
             #
         use_g.append(deepcopy(use_ref_node))

--- a/svg2tikz/extensions/tikz_export_effect.inx
+++ b/svg2tikz/extensions/tikz_export_effect.inx
@@ -2,9 +2,6 @@
     <_name>Export to TikZ path</_name>
     <id>net.texample.tools.svg.export_tikz.effect</id>
     <dependency type="executable" location="extensions">tikz_export.py</dependency>
-    <dependency type="executable" location="extensions">inkex.py</dependency>
-    <dependency type="executable" location="extensions">simplepath.py</dependency>
-    <dependency type="executable" location="extensions">simplestyle.py</dependency>
     <param name="tab" type="notebook">
         <page name="options" _gui-text="Options">
             <param name="codeoutput" type="optiongroup" _gui-text="Output">
@@ -21,7 +18,7 @@
             <param name="clipboard" type="boolean" _gui-text="Export to clipboard">false</param>
             <param name="wrap" type="boolean" _gui-text="Wrap paths">true</param>
             <param name="indent" type="boolean" _gui-text="Indent groups">true</param>
-            <param name="output" type="string" _gui-text="Output filename">none</param>
+            <param name="tikzoutput" type="string" _gui-text="Output filename">none</param>
             
             <param name="latexpathtype" type="boolean" _gui-text="Path comply for tikz mode">false</param>
             <param name="removeabsolute" type="string" _gui-text="Remove from path"></param>

--- a/svg2tikz/extensions/tikz_export_output.inx
+++ b/svg2tikz/extensions/tikz_export_output.inx
@@ -3,8 +3,6 @@
     <id>net.texample.tools.svg.export_tikz.output</id>
 	<dependency type="executable" location="extensions">tikz_export.py</dependency>
     <dependency type="executable" location="extensions">inkex.py</dependency>
-    <dependency type="executable" location="extensions">simplepath.py</dependency>
-    <dependency type="executable" location="extensions">simplestyle.py</dependency>
     <param name="tab" type="notebook">
             <page name="options" _gui-text="Options">
                 <param name="codeoutput" type="optiongroup" _gui-text="Output">


### PR DESCRIPTION
Converted for new Inkscape 1.x, fixing a lot of warning and fix clipboard exporter for Windows platform.