### PR TITLE
Fix side effects from 9ed6a73.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='svg2tikz',
       author='Kjell Magne Fauske',
       author_email='kjellmf@gmail.com',
       url="https://github.com/kjellmf/svg2tikz",
-      packages=['svg2tikz', 'svg2tikz.extensions', 'svg2tikz.inkexlib'],
+      packages=['svg2tikz', 'svg2tikz.extensions', 'svg2tikz.inkex'],
 
       scripts=['scripts/svg2tikz'],
       classifiers=[


### PR DESCRIPTION
`inkexlib` was renamed to `inkex`. This was causing build errors:
```
Defaulting to user installation because normal site-packages is not writeable
Processing /home/user/Documents/GitHub/svg2tikz
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [11 lines of output]
      /home/user/.local/lib/python3.10/site-packages/setuptools/dist.py:530: UserWarning: Normalizing '1.0.0dev' to '1.0.0.dev0'
        warnings.warn(tmpl.format(**locals()))
      running egg_info
      creating /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info
      writing /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/dependency_links.txt
      writing entry points to /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/entry_points.txt
      writing requirements to /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/requires.txt
      writing top-level names to /tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-ibq5xnww/svg2tikz.egg-info/SOURCES.txt'
      error: package directory 'svg2tikz/inkexlib' does not exist
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```