### PR TITLE
Fix build from CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='svg2tikz',
       author='Kjell Magne Fauske',
       author_email='kjellmf@gmail.com',
       url="https://github.com/kjellmf/svg2tikz",
-      packages=['svg2tikz', 'svg2tikz.extensions', 'svg2tikz.inkexlib'],
+      packages=['svg2tikz', 'svg2tikz.extensions', 'svg2tikz.inkex', 'svg2tikz.inkex.elements'],
 
       scripts=['scripts/svg2tikz'],
       classifiers=[


### PR DESCRIPTION
Currently when performing a clean build of the project, the `svg2tikz.inkex.elements` package is missing when running svg2tikz. This pull request aims to fix this issue, by adding it to the setup process. This fix has been tested locally on my machine, running Linux 6.1.6-arch1-1 with python 3.10.9

Additionally I would suggest adding a GitHub Action to verify that the project is able to install through the CLI, however that is for another pull request
