### PR TITLE
Changing inkex installation to reference to inkscape's gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # SVG2TikZ (Inkscape 1.x.x compatible)
+[![Documentation Status](https://readthedocs.org/projects/svg2tikz/badge/?version=latest)](https://svg2tikz.readthedocs.io/en/latest/?badge=latest)
 
-SVG2TikZ, formally known as Inkscape2TikZ ,are a set of tools for converting SVG graphics to TikZ/PGF code. 
+SVG2TikZ, formally known as Inkscape2TikZ ,are a set of tools for converting SVG graphics to TikZ/PGF code.
 This project is licensed under the GNU GPL  (see  the [LICENSE](/LICENSE) file).
+
+## Documentation and installation
+All the informations to install and use `SVG2TikZ` can be found in our [Documentation](https://svg2tikz.readthedocs.io/en/latest).
 
 ## Changes, Bug fixes and Known Problems from the original
 
@@ -15,6 +19,5 @@ This project is licensed under the GNU GPL  (see  the [LICENSE](/LICENSE) file).
 Known Problems
 - Currently only images that are "linked" in svg are exported. Base64 embed is not yet supported so avoid choosing embed option
 - Grouped elements will not work. So ungroup everything
-- Transformation like rotation is not working
 
 More documentation can be found in the [docs/](/docs/index.rst) directory.

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ except ImportError:
 
 
 setup(name='svg2tikz',
-      version='1.0.0dev',
+      version='1.1.0dev',
       description='An SVG to TikZ converter',
-      author='Kjell Magne Fauske',
-      author_email='kjellmf@gmail.com',
+      author='Louis Devillez, Kjell Magne Fauske',
+      author_email='louis.devillez@gmail.com, kjellmf@gmail.com',
       url="https://github.com/kjellmf/svg2tikz",
-      packages=['svg2tikz', 'svg2tikz.extensions', 'svg2tikz.inkex', 'svg2tikz.inkex.elements'],
+      packages=['svg2tikz', 'svg2tikz.extensions'],
 
       scripts=['scripts/svg2tikz'],
       classifiers=[
@@ -25,7 +25,10 @@ setup(name='svg2tikz',
           'Topic :: Text Processing :: Markup :: LaTeX',
           'Topic :: Utilities',
       ],
-      install_requires=['lxml'],
+      install_requires=[
+          'lxml',
+          "inkex @ git+https://gitlab.com/inkscape/extensions.git@1.2.x"
+          ],
       entry_points={
           'console_scripts': [
               'svg2tikz = svg2tikz.extensions.tikz_export:main_cmdline',


### PR DESCRIPTION
Now that inkscape use gitlab we can use it to reference the inkex installation instead of having a local copy

Also adding the link to the ReadTheDoc