### PR TITLE
Add simple arrow handling

### DIFF
--- a/tests/test_svg2tikz.py
+++ b/tests/test_svg2tikz.py
@@ -211,10 +211,9 @@ class MarkersTest(unittest.TestCase):
         code = convert_svg(arrows_svg, markings="ignore", codeoutput="codeonly")
         self.assertTrue('>' not in code)
 
-    # Still not implemented
-    # def test_marker2_options(self):
-        # code = convert_svg(arrows_svg, markings="arrows", codeoutput="codeonly")
-        # self.assertTrue('->' in code, 'code="%s"' % code)
+    def test_marker2_options(self):
+        code = convert_svg(arrows_svg, markings="arrows", arrow=">", codeoutput="codeonly")
+        self.assertTrue('->' in code, 'code="%s"' % code)
 
 
 # https://github.com/kjellmf/svg2tikz/issues/20


### PR DESCRIPTION
Changes:
- Adding the `interpret` marking option which interpret the name of the end symbol to add the corresponding arrow (improving work here could be done)
- Adding the `arrow`marking option which add the arrow style from the option `arrow`
- Both options works with reversed arrow.
- The `include` option for the arrow is still not implemented