### PR TITLE
Change tikz unit + change origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ All the informations to install (as an inkscape extension) and use `SVG2TikZ` ca
 
 ## Changes, Bug fixes and Known Problems from the original
 
+### V1.2.0
+- Adding option to set document unit `input-unit` and the output unit `output-unit`
+- Now the tikz output used the unit define by `output-unit`
+- Now the default behaviour will read the height of the svg and use the bottom left corner as reference
+- This option can be disabled with --noreversey
+
+
 ### V1.1.1
 - Supporting svg encoded in utf-8
 - Simple `Symbol` handling

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "svg2tikz"
-version = "1.1.0"
+version = "1.2.0"
 description = "Tools for converting SVG graphics to TikZ/PGF code"
 authors = ["ldevillez <louis.devillez@gmail.com>"]
 license = "GNU GPL"


### PR DESCRIPTION
- Adding option to set document unit `input-unit` and the output unit `output-unit`
- Now the tikz output used the unit define by `output-unit`
- Now the default behaviour will read the height of the svg and use the bottom left corner as reference
- This option can be disabled with --noreversey

Those options are not yet available updatable in the inkscape extension, it will use the default behaviour
Should close #9