### PR TITLE
Correct path punch when empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ All the informations to install (as an inkscape extension) and use `SVG2TikZ` ca
 
 ## Changes, Bug fixes and Known Problems from the original
 
+### V1.3.1
+- Correcting path punch error
+
 ### V1.3.0
 - Adding linting and formating to the project
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "svg2tikz"
-version = "1.2.0"
+version = "1.3.1"
 description = "Tools for converting SVG graphics to TikZ/PGF code"
 authors = ["ldevillez <louis.devillez@gmail.com>"]
 license = "GNU GPL"

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -1312,7 +1312,8 @@ class TikZPathExporter(inkex.Effect):
                 try:
                     _, xy = path_punches
                     path_punches[1] = [self.convert_unit(str(val)) for val in xy]
-                    path_punches[1][1] = self.update_height(path_punches[1][1])
+                    if len(path_punches[1]) > 1:
+                        path_punches[1][1] = self.update_height(path_punches[1][1])
                 except ValueError:
                     pass
         except ValueError:


### PR DESCRIPTION
# Problem
Path punch can be empty (Z) option for example.
Error raised in #89 

