### PR TITLE
Fix noreversey with rectangle and translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ All the informations to install (as an inkscape extension) and use `SVG2TikZ` ca
 
 ## Changes, Bug fixes and Known Problems from the original
 
+### V1.3.2
+- Updating all the tests
+- Fixing calc_arc function
+- Fixing noreversey function
+
 ### V1.3.1
 - Correcting path punch error
 

--- a/pylintrc
+++ b/pylintrc
@@ -288,7 +288,7 @@ max-attributes=12
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=15
 
 # Maximum number of locals for function / method body.
 max-locals=25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "svg2tikz"
-version = "1.3.1"
+version = "1.3.2"
 description = "Tools for converting SVG graphics to TikZ/PGF code"
 authors = ["ldevillez <louis.devillez@gmail.com>"]
 license = "GNU GPL"

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -1213,7 +1213,9 @@ class TikZPathExporter(inkex.Effect):
             if cmd == "translate":
                 x, y = [self.convert_unit(str(val)) for val in params]
                 if not self.options.noreversey:
-                    y *= -1 #Update height reverse the sign of y so it should also be the case for a translation
+                    y *= (
+                        -1
+                    )  # Update height reverse the sign of y so it should also be the case for a translation
                 # y = self.update_height(y)
                 options.append("shift={" + f"({x or '0'},{y or '0'})" + "}")
 
@@ -1360,7 +1362,7 @@ class TikZPathExporter(inkex.Effect):
             width = self.convert_unit(node.get("width", "0"))
             height = self.convert_unit(node.get("height", "0"))
             if not self.options.noreversey:
-                height *= -1 # y direction should be reversed
+                height *= -1  # y direction should be reversed
             if width == 0.0 or height == 0.0:
                 return None, []
             if inset:

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -260,7 +260,7 @@ STANDALONE_TEMPLATE = (
 %(colorcode)s
 %(gradientcode)s
 \def \globalscale {%(scale)f}
-\begin{tikzpicture}[y=1%(unit)s, x=1%(unit)s, yscale=\globalscale,"""
+\begin{tikzpicture}[y=1%(unit)s, x=1%(unit)s, yscale=%(ysign)s\globalscale,"""
     r"""xscale=\globalscale, inner sep=0pt, outer sep=0pt%(extraoptions)s]
 %(pathcode)s
 \end{tikzpicture}
@@ -273,7 +273,7 @@ FIG_TEMPLATE = (
 %(colorcode)s
 %(gradientcode)s
 \def \globalscale {%(scale)f}
-\begin{tikzpicture}[y=1%(unit)s, x=1%(unit)s, yscale=\globalscale,"""
+\begin{tikzpicture}[y=1%(unit)s, x=1%(unit)s, yscale=%(ysign)s\globalscale,"""
     r"""xscale=\globalscale, inner sep=0pt, outer sep=0pt%(extraoptions)s]
 %(pathcode)s
 \end{tikzpicture}
@@ -1708,6 +1708,7 @@ class TikZPathExporter(inkex.Effect):
                 "pathcode": string,
                 "colorcode": self.color_code,
                 "unit": self.options.output_unit,
+                "ysign": "-" if self.options.noreversey else "",
                 "cropcode": cropcode,
                 "extraoptions": extraoptions,
                 "gradientcode": self.gradient_code,
@@ -1718,6 +1719,7 @@ class TikZPathExporter(inkex.Effect):
                 "pathcode": string,
                 "colorcode": self.color_code,
                 "unit": self.options.output_unit,
+                "ysign": "-" if self.options.noreversey else "",
                 "extraoptions": extraoptions,
                 "gradientcode": self.gradient_code,
                 "scale": self.options.scale,

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -1212,7 +1212,9 @@ class TikZPathExporter(inkex.Effect):
         for cmd, params in transform:
             if cmd == "translate":
                 x, y = [self.convert_unit(str(val)) for val in params]
-                y = self.update_height(y)
+                if not self.options.noreversey:
+                    y *= -1 #Update height reverse the sign of y so it should also be the case for a translation
+                # y = self.update_height(y)
                 options.append("shift={" + f"({x or '0'},{y or '0'})" + "}")
 
                 # There is bug somewere.
@@ -1357,6 +1359,8 @@ class TikZPathExporter(inkex.Effect):
             # map from svg to tikz
             width = self.convert_unit(node.get("width", "0"))
             height = self.convert_unit(node.get("height", "0"))
+            if not self.options.noreversey:
+                height *= -1 # y direction should be reversed
             if width == 0.0 or height == 0.0:
                 return None, []
             if inset:

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -42,6 +42,16 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "pentagone_round_corner"
         create_test_from_filename(filename, self)
 
+    def test_three_rectangles_with_translation(self):
+        """Test complete converte pentagone with round corner"""
+        filename = "three_rectangles_with_translate"
+        create_test_from_filename(filename, self)
+
+    def test_four_basics_rectangles(self):
+        """Test complete converte pentagone with round corner"""
+        filename = "four_basics_rectangles"
+        create_test_from_filename(filename, self)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tikz_path_exporter.py
+++ b/tests/test_tikz_path_exporter.py
@@ -214,19 +214,19 @@ class TestTikZPathExporter(unittest.TestCase):
 
 \def \globalscale {1.000000}
 \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
-\path[draw=blue,line width=0.200cm,rounded corners=0.0000cm] (0.1, 3.9) rectangle (119.9, 43.7);
+\path[draw=blue,line width=0.200cm,rounded corners=0.0000cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
 
 
 
-\path[draw=navy,fill=yellow,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, 14.000000000000002);
+\path[draw=navy,fill=yellow,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, 14.000000000000002);
+\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, 14.000000000000002);
+\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 

--- a/tests/testfiles/four_basics_rectangles.svg
+++ b/tests/testfiles/four_basics_rectangles.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="12cm" height="4cm" viewBox="0 0 1200 400"
+     xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <desc>Example rect01 - rectangle with sharp corners</desc>
+  <!-- Show outline of canvas using 'rect' element -->
+  <rect x="1" y="1" width="1198" height="398" id="rect1"
+        fill="none" stroke="blue" stroke-width="2"/>
+  <rect x="400" y="100" width="400" height="200" id="rect2"
+        fill="yellow" stroke="navy" stroke-width="10"  />
+  <rect x="400" y="100" width="400" height="200" id="rect3"
+        fill="none" stroke="green" stroke-width="10"  />
+  <rect x="400" y="100" width="400" height="200" id="rect4"
+        fill="none" stroke="green" stroke-width="10"  />
+</svg>

--- a/tests/testfiles/four_basics_rectangles.tex
+++ b/tests/testfiles/four_basics_rectangles.tex
@@ -1,0 +1,33 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{blue}{RGB}{0,0,255}
+\definecolor{navy}{RGB}{0,0,128}
+\definecolor{yellow}{RGB}{255,255,0}
+\definecolor{green}{RGB}{0,128,0}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
+\path[draw=blue,line width=0.200cm,rounded corners=0.0000cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
+
+
+
+\path[draw=navy,fill=yellow,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+
+
+
+\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+
+
+
+\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+
+
+
+
+\end{tikzpicture}
+\end{document}

--- a/tests/testfiles/three_rectangles_with_translate.svg
+++ b/tests/testfiles/three_rectangles_with_translate.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="49.203857mm" height="40.278111mm" viewBox="0 0 49.203857 40.278111" version="1.1" id="svg3305" sodipodi:docname="r.svg" inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
+  <defs id="defs8"/>
+  <sodipodi:namedview id="namedview3307" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" showgrid="false" inkscape:pageshadow="2" inkscape:pageopacity="0.0" inkscape:pagecheckerboard="0" inkscape:document-units="mm" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0" inkscape:zoom="2.1166667" inkscape:cx="-37.795275" inkscape:cy="11.811023" inkscape:window-width="1920" inkscape:window-height="1029" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:current-layer="layer1"/>
+  <g id="layer1" transform="translate(-14.9546, -59.5168)" style="">
+    <rect style="" id="rect3331" width="28.4118" height="26.115294" x="15.20459" y="63.424545"/>
+    <rect style="" id="rect3333" width="21.380461" height="18.904953" x="33.686737" y="80.639969"/>
+    <rect style="" id="rect3335" width="20.292057" height="3.6577303" x="43.61639" y="59.766811"/>
+  </g>
+</svg>

--- a/tests/testfiles/three_rectangles_with_translate.tex
+++ b/tests/testfiles/three_rectangles_with_translate.tex
@@ -1,0 +1,27 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
+\begin{scope}[shift={(-1.49546,5.9516800000000005)}]
+  \path[fill,rounded corners=0.0000cm] (1.520459, -2.3146433999999996) rectangle (4.361639, -4.9261728);
+
+
+
+  \path[fill,rounded corners=0.0000cm] (3.3686737000000004, -4.036185799999998) rectangle (5.506719800000001, -5.926681099999998);
+
+
+
+  \path[fill,rounded corners=0.0000cm] (4.361639000000001, -1.9488699999999994) rectangle (6.3908447000000015, -2.3146430299999996);
+
+
+
+\end{scope}
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
We apply the y-transformation on each object but then we should also inverse the sign when using rectangle or translation.