### PR TITLE
Add additional split string for dasharray

### DIFF
--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -1147,8 +1147,11 @@ class TikZPathExporter(inkex.Effect):
         # TODO: dash phase is not the same between tikz and inkscape for rectangle.
         dasharray = state.stroke.get("stroke-dasharray")
         if dasharray and dasharray != "none":
+            split_str = ","
+            if split_str not in dasharray:
+                split_str = " "
             lengths = list(
-                map(self.convert_unit, [i.strip() for i in dasharray.split(",")])
+                map(self.convert_unit, [i.strip() for i in dasharray.split(split_str)])
             )
             dashes = []
             for idx, length in enumerate(lengths):


### PR DESCRIPTION
Thanks for your great work! When I was using the tools, I found it has some issue on dash line. In my case, the dasharray part of my svg file is space-separated. Therefore, I add the space as an additional split string for dasharray.

<img width="467" alt="image" src="https://user-images.githubusercontent.com/66028151/231674965-548eec09-633c-4762-b3ba-7725df999e37.png">
