### PR TITLE
Additional spaces in gui help and add copy-to-clipboard to effect

### DIFF
--- a/svg2tikz/extensions/tikz_export_effect.inx
+++ b/svg2tikz/extensions/tikz_export_effect.inx
@@ -7,6 +7,7 @@
     <page name="options" gui-text="Document">
       <label appearance="header">Output file</label>
         <param name="output" type="path" _gui-text="Output filename">none</param>
+        <param name="clipboard" type="boolean" _gui-text="Export to clipboard">false</param>
       <separator />
       <label appearance="header">Tikz option</label>
       <param name="codeoutput" type="optiongroup" gui-text="Tex template" gui-description="Template for the tikz code output">

--- a/svg2tikz/extensions/tikz_export_effect.inx
+++ b/svg2tikz/extensions/tikz_export_effect.inx
@@ -63,12 +63,9 @@
       <label>
         An Inkscape extension for exporting SVG paths as TikZ/PGF paths.
         <br/>
+        <br/>The extension will export the selected paths. If no path is selected, all paths are exported.
         <br/>
-        The extension will export the selected paths. If no path is selected, all paths are exported.
-        <br/>
-        <br/>
-
-        If you find a bug or you can report it to the github repository:
+        <br/>If you find a bug or you can report it to the github repository:
       </label>
       <label appearance="url">https://github.com/xyz2tex/svg2tikz</label>
       <label>

--- a/svg2tikz/extensions/tikz_export_output.inx
+++ b/svg2tikz/extensions/tikz_export_output.inx
@@ -60,12 +60,9 @@
       <label>
         An Inkscape extension for exporting SVG paths as TikZ/PGF paths.
         <br/>
+        <br/>The extension will NOT export the selected paths. If you want to export only selected path, use the extension from the extension and not from the save-as menu.
         <br/>
-        The extension will NOT export the selected paths. If you want to export only selected path, use the extension from the extension and not from the save-as menu.
-        <br/>
-        <br/>
-
-        If you find a bug or you can report it to the github repository:
+        <br/>If you find a bug or you can report it to the github repository:
       </label>
       <label appearance="url">https://github.com/xyz2tex/svg2tikz</label>
       <label>


### PR DESCRIPTION
# Description

Correct the spacing in the gui help and add the copy-to-clipboard to the effect extension

Fixes #106 #105 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- Testing the visual for the gui
- Testing if a blank svg is correctly exported to clipboard


# Checklist:


- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
