### PR TITLE
Avoid writing "rounded corners=0.0000cm"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Removing misplaced <br/> leading to warning from inkscape
 - Typo in tag leading to mismtach and error from inkscape
+- No rounded corners by default
 ### Security
 
 ## v2.0.0 - 2023/05/04

--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -1367,7 +1367,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         """Extract shape data from node"""
         options = []
         if node.tag == _ns("rect"):
-            inset = node.get("rx", "0") or node.get("ry", "0")
+            inset = node.get("rx", 0) or node.get("ry", 0)
             # TODO: ry <> rx is not supported by TikZ. Convert to path?
             x = self.convert_unit(node.get("x", "0"))
             y = self.update_height(self.convert_unit(node.get("y", "0")))

--- a/tests/test_tikz_path_exporter.py
+++ b/tests/test_tikz_path_exporter.py
@@ -214,19 +214,19 @@ class TestTikZPathExporter(unittest.TestCase):
 
 \def \globalscale {1.000000}
 \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
-\path[draw=blue,line width=0.200cm,rounded corners=0.0000cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
+\path[draw=blue,line width=0.200cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
 
 
 
-\path[draw=navy,fill=yellow,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=navy,fill=yellow,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=green,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=green,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 

--- a/tests/testfiles/four_basics_rectangles.tex
+++ b/tests/testfiles/four_basics_rectangles.tex
@@ -12,19 +12,19 @@
 
 \def \globalscale {1.000000}
 \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
-\path[draw=blue,line width=0.200cm,rounded corners=0.0000cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
+\path[draw=blue,line width=0.200cm] (0.1, 3.9) rectangle (119.9, -35.900000000000006);
 
 
 
-\path[draw=navy,fill=yellow,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=navy,fill=yellow,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=green,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 
-\path[draw=green,line width=1.000cm,rounded corners=0.0000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
+\path[draw=green,line width=1.000cm] (40.00000000000001, -6.000000000000002) rectangle (80.00000000000001, -26.000000000000007);
 
 
 

--- a/tests/testfiles/three_rectangles_with_translate.tex
+++ b/tests/testfiles/three_rectangles_with_translate.tex
@@ -9,15 +9,15 @@
 \def \globalscale {1.000000}
 \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
 \begin{scope}[shift={(-1.49546,5.9516800000000005)}]
-  \path[fill,rounded corners=0.0000cm] (1.520459, -2.3146433999999996) rectangle (4.361639, -4.9261728);
+  \path[fill] (1.520459, -2.3146433999999996) rectangle (4.361639, -4.9261728);
 
 
 
-  \path[fill,rounded corners=0.0000cm] (3.3686737000000004, -4.036185799999998) rectangle (5.506719800000001, -5.926681099999998);
+  \path[fill] (3.3686737000000004, -4.036185799999998) rectangle (5.506719800000001, -5.926681099999998);
 
 
 
-  \path[fill,rounded corners=0.0000cm] (4.361639000000001, -1.9488699999999994) rectangle (6.3908447000000015, -2.3146430299999996);
+  \path[fill] (4.361639000000001, -1.9488699999999994) rectangle (6.3908447000000015, -2.3146430299999996);
 
 
 


### PR DESCRIPTION
# Description

In converting `<rect>` without rounded corners, the converter always added `rounded corners=0.0000cm`. This was because in this line,
https://github.com/xyz2tex/svg2tikz/blob/fb694ebf5d1c41898d92d6093b8790de7d341188/svg2tikz/extensions/tikz_export.py#L1370
`inset` is set to `"0"`, which becomes `True` in this check:

https://github.com/xyz2tex/svg2tikz/blob/fb694ebf5d1c41898d92d6093b8790de7d341188/svg2tikz/extensions/tikz_export.py#L1382-L1386

I've changed `"0"` to `0` in line 1370 to avoid printing the unnecessary instruction in the conversion.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [ ] I have updated the changelog with the corresponding changes
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
