### PR TITLE
Fix display none in groups

### DIFF
--- a/svg2tikz/extensions/tikz_export.py
+++ b/svg2tikz/extensions/tikz_export.py
@@ -626,6 +626,7 @@ class GraphicsState:
 
         display = style.get("display") or node.get("display")
         visibility = style.get("visibility") or node.get("visibility")
+
         if display == "none" or visibility == "hidden":
             is_visible = False
         else:
@@ -1094,7 +1095,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         # TODO should be reworked to follow pylint
         # pylint: disable=too-many-branches
         # pylint: disable=too-many-statements
-        if not state.is_visible:
+        if not state.is_visible or not accumulated_state.is_visible:
             return [], []
 
         options = []
@@ -1338,7 +1339,6 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             # p = simplepath.parsePath(raw_path)
             p = inkex.Path(raw_path).to_arrays()
 
-            #             logging.warning('Path Values %s'%(len(p)),);
             for path_punches in p:
                 try:
                     _, xy = path_punches

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -52,6 +52,11 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "four_basics_rectangles"
         create_test_from_filename(filename, self)
 
+    def test_display_none_in_groups(self):
+        """Test complete converte pentagone with round corner"""
+        filename = "display_none_in_group"
+        create_test_from_filename(filename, self)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testfiles/display_none_in_group.svg
+++ b/tests/testfiles/display_none_in_group.svg
@@ -26,7 +26,7 @@
      showgrid="false"
      inkscape:zoom="0.9943056"
      inkscape:cx="370.10754"
-     inkscape:cy="577.28731"
+     inkscape:cy="577.2873"
      inkscape:window-width="1918"
      inkscape:window-height="1173"
      inkscape:window-x="0"
@@ -56,5 +56,23 @@
        y="64.131813"
        ry="12.424748"
        display="none" />
+    <g
+       id="g406"
+       display="none">
+      <ellipse
+         style="opacity:0.7;fill:#ff0000;stroke:#ff0000;stroke-width:1.502;stroke-opacity:0.992463"
+         id="path292"
+         cx="86.954292"
+         cy="100.81785"
+         rx="16.161299"
+         ry="16.624804" />
+      <ellipse
+         style="opacity:0.7;fill:#ff0000;stroke:#ff0000;stroke-width:1.502;stroke-opacity:0.992463"
+         id="path294"
+         cx="107.06225"
+         cy="97.119102"
+         rx="17.713324"
+         ry="10.947024" />
+    </g>
   </g>
 </svg>

--- a/tests/testfiles/display_none_in_group.svg
+++ b/tests/testfiles/display_none_in_group.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (1:1.2.2+202212051552+b0a8486541)"
+   sodipodi:docname="none_display.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.9943056"
+     inkscape:cx="370.10754"
+     inkscape:cy="577.28731"
+     inkscape:window-width="1918"
+     inkscape:window-height="1173"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="opacity:0.7;fill:#ff0000;stroke:#ff0000;stroke-width:1.502;stroke-opacity:0.992463"
+       id="rect234"
+       width="58.518299"
+       height="45.678543"
+       x="50.180828"
+       y="40.217339"
+       ry="15.535867" />
+    <rect
+       style="opacity:0.7;fill:#ff0000;stroke:#ff0000;stroke-width:1.502;stroke-opacity:0.992463"
+       id="rect236"
+       width="51.822514"
+       height="24.849497"
+       x="68.337151"
+       y="64.131813"
+       ry="12.424748"
+       display="none" />
+  </g>
+</svg>

--- a/tests/testfiles/display_none_in_group.tex
+++ b/tests/testfiles/display_none_in_group.tex
@@ -17,6 +17,14 @@
 
 
 
+    \path (8.6954, 19.6182) ellipse (1.6161cm and 1.6625cm);
+
+
+
+    \path (10.7062, 19.9881) ellipse (1.7713cm and 1.0947cm);
+
+
+
 
 \end{tikzpicture}
 \end{document}

--- a/tests/testfiles/display_none_in_group.tex
+++ b/tests/testfiles/display_none_in_group.tex
@@ -1,0 +1,22 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{cff0000}{RGB}{255,0,0}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
+  \path[draw=cff0000,fill=cff0000,opacity=0.700,draw opacity=0.992,line width=0.150cm,rounded corners=1.5535867cm] (5.0180828, 25.6782661) rectangle (10.8699127, 21.110411799999998);
+
+
+
+  \path[rounded corners=1.2424748cm] (6.833715100000001, 23.286818699999998) rectangle (12.015966500000001, 20.801868999999996);
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

Svg elements with a `display: none` should not be drawn by tikz

Fixes #12 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Adding a test with elements with `display: none`


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
