### PR TITLE
fix text node bugs

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1125,7 +1125,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         p = self.round_coord(self.convert_unit_coord(p))
 
         return (
-            f" \node[above right] (node.get_id()) at {self.coord_to_tz(p)}"
+            f" \\node[above right] ({node.get_id()}) at {self.coord_to_tz(p)}"
             + "{"
             + f"{textstr}"
             + "}"


### PR DESCRIPTION
# Description

The `_handle_text` method uses Python f-strings to generate the TikZ code, but there were some issues with escaping and interpolating.

This PR fixes the f-string.

I did not find an associated GitHub issue for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Use the following svg:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- Created with Inkscape (http://www.inkscape.org/) -->

<svg width="210mm" height="297mm" viewBox="0 0 210 297" version="1.1" id="svg1" sodipodi:docname="test2.svg" inkscape:version="1.3 (0e150ed6c4, 2023-07-21)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
  <sodipodi:namedview
     id="namedview1"
     pagecolor="#ffffff"
     bordercolor="#666666"
     borderopacity="1.0" />
  <defs id="defs1" />
  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1">
    <text
       xml:space="preserve"
       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
       x="68.727272"
       y="110.80519"
       id="text1"><tspan
         sodipodi:role="line"
         id="tspan1"
         style="stroke-width:0.264583"
         x="68.727272"
         y="110.80519">asdf</tspan></text>
  </g>
</svg>
```

Then run this command:

```bash
svg2tikz ~/test.svg | grep asdf
```

Previously, the script returned this output:

```
ode[above right] (node.get_id()) at (6.8727, 18.6195){asdf};
```

With the fix, this output is returned:

```
   \node[above right] (text1) at (6.8727, 18.6195){asdf};
```



# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [ ] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
