### PR TITLE
FIX: adding commandline script to pyproject + rephrasing doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Correcting licence in the pyproject
 - Unify conversion of coordinate: (x, y)
 - Convert_file and convert_svg functions are now directly accesible from root
+- Fixing the installation of svg2tikz as command line tool
 ### Deprecated
 - Gradient are commented for the time being
 ### Removed

--- a/docs/moduleguide.rst
+++ b/docs/moduleguide.rst
@@ -1,7 +1,7 @@
 
 .. _module-guide:
 
-Module guide
+package guide
 ============
 
 .. module:: svg2tikz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,7 @@ secondary = true
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.poetry.scripts]
+svg2tikz = "svg2tikz.tikz_export:main_cmdline"


### PR DESCRIPTION
# Description

Fix the auto install of `svg2tikz` as a command line too*l

Fixes #133 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Installed in a virtual environement. Checked that `svg2tikz` was a valid command from the command line


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
