### PR TITLE
Adding metadata tag to non rendered tags

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -175,7 +175,16 @@ def filter_tag(node):
     # As it is done in lxml
     if node.tag == etree.Comment:
         return False
-    if node.TAG in ["desc", "namedview", "defs", "svg", "symbol", "title", "style"]:
+    if node.TAG in [
+        "desc",
+        "namedview",
+        "defs",
+        "svg",
+        "symbol",
+        "title",
+        "style",
+        "metadata",
+    ]:
         return False
     return True
 


### PR DESCRIPTION
# Description
`Metadata` is a valid svg tag but it should not be directly rendered.

Fixes #141

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the svg from #141. The tikz output is similar to the svg.

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
