### PR TITLE
Fix: try except for Attribute Error with is_visible

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1191,8 +1191,11 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             if node.TAG == "g":
                 string += self._handle_group(node)
                 continue
-
-            goptions = self.style_to_tz(node) + self.trans_to_tz(node)
+            try:
+                goptions = self.style_to_tz(node) + self.trans_to_tz(node)
+            except AttributeError as msg:
+                attr = msg.args[0].split("attribute")[1].split(".")[0]
+                logging.warning("%s attribute cannot be represented", attr)
 
             cmd = []
 


### PR DESCRIPTION
# Description

When a node should not be displayed it was compared to a list of TAG (`filter_tag`) but this list is not exhaustive and some error rised. With a try and except, it is possible to catch all those errors.

Filter_tag should be completed as we have more control on what happens

Fixes #145 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested in command line and with inkscape. More test should be added (#143)


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
