### PR TITLE
Feat: try except for importing sys.stdout.buffer

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -40,6 +40,12 @@ import inkex
 from inkex.transforms import Vector2d
 from lxml import etree
 
+try:
+    SYS_OUTPUT_BUFFER = sys.stdout.buffer
+except AttributeError:
+    logging.warning("Sys has no output buffer, redirecting to None")
+    SYS_OUTPUT_BUFFER = None
+
 #### Utility functions and classes
 
 TIKZ_BASE_COLOR = [
@@ -1337,7 +1343,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
 
                 self.options.output.write(out)
 
-    def run(self, args=None, output=sys.stdout.buffer):
+    def run(self, args=None, output=SYS_OUTPUT_BUFFER):
         """
         Custom inkscape entry point to remove agr processing
         """


### PR DESCRIPTION
# Description

If we import svg2tikz in Pyzo it will fails as because Pyzo replace `sys.stdout.buffer`. In this case it is not used so it can be redefined (pyzo/pyzo#911)

Fixes #144 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test suite runned


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
