### PR TITLE
Text is filled with background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Cleaning of the comments
 - Basic colors are not redefined anymore
 - Adding logo for SVG2TikZ
+- Adding basic switch tag handle
+- Adding failsafe for non defined sys.stdout.buffer
 ### Changed
 - Using style from new inkex
 - Using path from new inkex
@@ -20,6 +22,7 @@
 - Unify conversion of coordinate: (x, y)
 - Convert_file and convert_svg functions are now directly accesible from root
 - Fixing the installation of svg2tikz as command line tool
+- Try excepting non existing tags in a svg
 ### Deprecated
 - Gradient are commented for the time being
 ### Removed

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -792,7 +792,11 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         options = []
 
         # Stroke and fill
-        for use_path in [("stroke", "draw"), ("fill", "fill")]:
+        for use_path in (
+            [("fill", "text")]
+            if node.TAG == "text"
+            else [("stroke", "draw"), ("fill", "fill")]
+        ):
             value = style.get(use_path[0])
             if value != "none" and value is not None:
                 options.append(

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -107,6 +107,11 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "switch_simple"
         create_test_from_filename(filename, self)
 
+    def test_text_fill_color(self):
+        """Test complete convert text with color case"""
+        filename = "text_fill_color"
+        create_test_from_filename(filename, self)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testfiles/text_fill_color.svg
+++ b/tests/testfiles/text_fill_color.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="342px"
+   height="306px"
+   style="background-color:rgb(255, 255, 255)"
+   version="1.1"
+   viewBox="-.5 -.5 342 306"
+   id="svg12"
+   sodipodi:docname="text_fill_color.svg"
+   inkscape:version="1.3 (1:1.3+202307231459+0e150ed6c4)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.355882"
+     inkscape:cx="144.86159"
+     inkscape:cy="99.635389"
+     inkscape:window-width="1918"
+     inkscape:window-height="1173"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg12" />
+  <text
+     x="127.93532"
+     y="57.697941"
+     font-family="Helvetica"
+     font-size="11px"
+     text-anchor="middle"
+     id="text2">Default</text>
+  <text
+     x="127.93532"
+     y="71.314354"
+     font-family="Helvetica"
+     font-size="11px"
+     text-anchor="middle"
+     id="text2-3"
+     fill="#ff0000">Red</text>
+  <text
+     x="127.93532"
+     y="84.930771"
+     font-family="Helvetica"
+     font-size="11px"
+     text-anchor="middle"
+     id="text2-6"
+     fill="#00FF00">Green</text>
+  <text
+     x="127.93532"
+     y="98.54718"
+     font-family="Helvetica"
+     font-size="11px"
+     text-anchor="middle"
+     id="text2-3-7"
+     fill="#0000FF">Blue</text>
+  <text
+     x="128.4743"
+     y="112.16359"
+     font-family="Helvetica"
+     font-size="11px"
+     text-anchor="middle"
+     id="text2-5"
+     fill="#000000">Black</text>
+</svg>

--- a/tests/testfiles/text_fill_color.tex
+++ b/tests/testfiles/text_fill_color.tex
@@ -1,0 +1,34 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{lime}{RGB}{0,255,0}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
+  \node[anchor=south west] (text2) at (3.385, 6.5697){Default};
+
+
+
+  \node[text=red,anchor=south west] (text2-3) at (3.385, 6.2094){Red};
+
+
+
+  \node[text=lime,anchor=south west] (text2-6) at (3.385, 5.8491){Green};
+
+
+
+  \node[text=blue,anchor=south west] (text2-3-7) at (3.385, 5.4889){Blue};
+
+
+
+  \node[text=black,anchor=south west] (text2-5) at (3.3992, 5.1286){Black};
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

The fill property of text in svg is the color of the text. The fill property of node in tikz code will be the background color. We need to change the name of the property to text when dealing with text

Fixes #152 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test file created and visual output checked


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
