### PR TITLE
fix verbose option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fixing the installation of svg2tikz as command line tool
 - Wrapping line now respect newline
 - Fixing error on treating polylines and polygones
+- Verbose option to add name of shapes and layers
 ### Security
 
 ## v2.1.0 - 2023/06/28

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -957,7 +957,8 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         if len(options) > 0 or self.options.verbose:
             # Remove it from the list
             if hide or self.options.verbose:
-                options.remove("none")
+                if "none" in options:
+                    options.remove("none")
 
             pstyles = [",".join(options)]
 

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -52,6 +52,11 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "circle"
         create_test_from_filename(filename, self)
 
+    def test_circle_verbose(self):
+        """Test complete convert circle"""
+        filename = "circle_verbose"
+        create_test_from_filename(filename, self, verbose=True)
+
     def test_ellipse(self):
         """Test complete convert ellipse"""
         filename = "ellipse"

--- a/tests/testfiles/circle_verbose.svg
+++ b/tests/testfiles/circle_verbose.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg1452"
+   inkscape:version="1.2.2 (1:1.2.2+202212051552+b0a8486541)"
+   sodipodi:docname="circle.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1454"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.6819304"
+     inkscape:cx="241.09202"
+     inkscape:cy="202.44595"
+     inkscape:window-width="1918"
+     inkscape:window-height="1150"
+     inkscape:window-x="1920"
+     inkscape:window-y="1104"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1449" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="opacity:1;fill:none;stroke:#000000;stroke-width:2;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:1"
+       id="path1573"
+       cx="27.318886"
+       cy="28.272858"
+       r="22.947573" />
+  </g>
+</svg>

--- a/tests/testfiles/circle_verbose.tex
+++ b/tests/testfiles/circle_verbose.tex
@@ -1,0 +1,20 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, inner sep=0pt, outer sep=0pt]
+  \begin{scope}[]%% layer1
+  %path1573
+  \path[draw=black,line cap=,line width=0.2cm] (2.7319, 26.8727) circle (2.2948cm);
+
+
+
+  \end{scope}
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

When using the `--verbose` option to add the name of layers and paths, it crashed. This PR fix the issue and add a simple test.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Visual inspection of the output


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
