### PR TITLE
fix line shape handling

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1180,7 +1180,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             p_b = self.convert_unit_coord(Vector2d(node.x2, node.y2))
             # check for zero lenght line
             if not ((p_a[0] == p_b[0]) and (p_a[1] == p_b[1])):
-                return f"{self.coord_to_tz(p_a)} -- {self.coord_to_tz(p_b)}"
+                return f"{self.coord_to_tz(p_a)} -- {self.coord_to_tz(p_b)}", []
 
         if node.TAG == "circle":
             center = self.convert_unit_coord(Vector2d(node.center.x, node.center.y))


### PR DESCRIPTION
# Description

I wanted to use the command line svg2tikz using this svg https://vega.github.io/editor/#/examples/vega-lite/stacked_bar_h (click on export as svg)

But when I ran the command it errored out as 

```
...
    pathcode, options = self._handle_shape(node)
ValueError: too many values to unpack (expected 2)
```

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Has been tested with the same svg

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [ ] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
