### PR TITLE
FIX: {end_ang} and {radi} not seen as variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix bug with arc where angles values were not replaced
 ### Security
 
 ## v3.0.0 - 12/12/2023

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1150,7 +1150,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
                 if ang != 0.0:
                     s += (
                         "{" + f"[rotate={ang}] arc({start_ang}"
-                        ":{end_ang}:{radi})" + "}"
+                        f":{end_ang}:{radi})" + "}"
                     )
                 else:
                     s += f"arc({start_ang}:{end_ang}:{radi})"


### PR DESCRIPTION
# Description
In this line:
https://github.com/xyz2tex/svg2tikz/blob/5069a1e8862a8a559d548ec0f74eeac500cf5e9b/svg2tikz/tikz_export.py#L1152
The formatted string literal (f-string) is interrupted by the line break. So in the next line:
https://github.com/xyz2tex/svg2tikz/blob/5069a1e8862a8a559d548ec0f74eeac500cf5e9b/svg2tikz/tikz_export.py#L1153
 The variables ```end_ang```,  ```radi``` and the escape characters ```{}``` were not recognised correctly, but were recognised as constant strings, generating the error ```Package PGF Math Error: Unknown function 'end_ang'/'radi' (in 'end_ang'/'radi')``` in LaTeX.
Adding the f-string alias ```f``` before the string ```":{end_ang}:{radi})" + "}"``` solves the problem.

I did not find an associated GitHub issue for this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Visual inspection of the output.
For example:
* #### Uses as input a svg file containing a path with an arc:
  <details>
  <summary>test.svg</summary>
  
  ```xml
  <?xml version="1.0" encoding="UTF-8" standalone="no"?>
  <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
  <svg xmlns="http://www.w3.org/2000/svg" version="1.0" viewBox="0.00 0.00 620.00 209.00">
  <g stroke-width="2.00" fill="none" stroke-linecap="butt">
  <path stroke="#808080" vector-effect="non-scaling-stroke" d="
    M 620.00 80.36
    Q 600.56 75.64 580.75 71.54
    Q 566.44 68.58 549.64 65.74
    Q 499.90 57.34 456.00 33.16
    Q 447.11 28.26 435.72 21.41
    Q 429.10 17.42 419.23 14.37
    C 403.77 9.57 387.35 10.58 373.02 18.06
    Q 368.31 20.52 363.78 23.42
    C 344.61 35.72 323.12 36.24 301.60 29.38
    C 296.28 27.69 291.50 28.49 286.49 25.25
    Q 275.26 17.98 262.25 21.46
    Q 256.37 23.03 247.34 28.35
    C 222.23 43.13 193.87 53.64 166.99 62.19
    C 149.51 67.75 126.65 73.76 106.18 79.97
    Q 60.96 93.67 14.46 102.25
    Q 7.03 103.62 0.00 105.26"
  />
  </g>
  <path fill="#000000" d="
    M 32.74 138.57
    L 32.75 138.85
    A 0.40 0.39 87.8 0 0 33.15 139.23
    C 37.17 139.13 41.04 139.84 45.10 140.20
    Q 67.99 142.19 90.73 143.93
    Q 112.97 145.63 149.23 146.60
    C 163.89 147.00 178.22 147.24 192.65 148.06
    C 199.71 148.46 206.79 148.58 213.75 149.15
    Q 240.37 151.32 263.75 152.86
    Q 272.81 153.45 281.50 153.87
    Q 312.83 155.37 350.49 155.86
    Q 352.51 155.89 354.74 155.95
    Q 427.80 157.98 492.45 159.76
    Q 494.59 159.82 494.56 161.97
    L 494.54 163.02
    Q 494.51 164.98 492.55 164.93
    Q 472.87 164.47 453.50 164.09
    Q 452.25 164.07 451.00 164.04
    Q 416.99 163.28 379.75 162.28
    Q 359.93 161.76 333.75 161.14
    Q 298.97 160.31 255.26 158.14
    Q 236.62 157.22 217.35 154.74
    Q 211.92 154.05 201.88 154.23
    C 199.44 154.27 196.97 153.80 194.49 153.75
    Q 133.21 152.53 72.22 147.95
    C 59.26 146.98 44.98 145.42 31.35 144.17
    C 25.19 143.60 18.71 143.67 12.80 142.30
    Q 10.03 141.65 8.34 139.36
    Q 7.93 138.80 8.44 138.33
    Q 11.52 135.53 16.45 134.89
    C 43.92 131.32 71.71 128.25 99.04 128.58
    Q 107.20 128.68 115.47 128.71
    Q 151.01 128.85 194.25 128.02
    Q 202.72 127.85 211.50 127.71
    Q 236.56 127.32 263.85 127.16
    C 271.53 127.12 278.11 122.30 285.70 121.67
    Q 307.31 119.89 331.70 118.82
    Q 371.31 117.08 401.25 118.74
    Q 420.57 119.81 432.10 119.10
    Q 449.02 118.07 472.08 115.72
    Q 489.44 113.96 515.44 114.74
    Q 560.63 116.09 603.69 121.76
    Q 605.31 121.97 606.57 123.02
    Q 608.00 124.20 607.24 125.04
    Q 605.61 126.83 603.43 126.62
    Q 566.22 123.02 532.51 120.53
    Q 516.79 119.36 500.49 119.86
    Q 476.19 120.60 463.00 121.84
    Q 449.18 123.15 437.10 124.10
    C 430.65 124.60 423.96 124.68 417.53 124.39
    Q 398.60 123.55 381.51 122.83
    Q 349.98 121.51 321.57 124.97
    Q 318.56 125.33 316.29 124.85
    Q 312.36 124.01 307.96 124.60
    Q 306.73 124.76 307.79 125.40
    Q 308.32 125.71 308.91 125.86
    Q 315.09 127.41 320.88 127.39
    Q 357.00 127.21 391.72 127.29
    Q 393.77 127.30 393.75 129.34
    L 393.74 130.40
    Q 393.72 132.48 391.64 132.53
    C 388.71 132.62 385.72 132.26 382.77 132.28
    Q 362.03 132.39 339.75 132.09
    Q 334.92 132.02 330.75 132.00
    C 305.18 131.85 280.11 131.61 255.00 132.24
    Q 235.59 132.72 216.25 132.81
    C 214.72 132.81 212.67 133.21 210.87 133.21
    Q 169.15 133.32 121.24 133.47
    C 104.76 133.52 88.24 134.03 71.77 134.78
    Q 57.92 135.41 32.85 138.44
    Q 32.73 138.45 32.74 138.57
    Z"
  />
  </svg>
  ```
  
  </details>

* ####  Then run ```svg2tikz``` as a Python module:
  ``` Python
  from svg2tikz import convert_file
  
  print(convert_file("test.svg"))
  ```
* #### Previously, the script returned this output:
  ```LaTeX
  
  \documentclass{article}
  \usepackage[utf8]{inputenc}
  \usepackage{tikz}
  
  \begin{document}
  \definecolor{grey}{RGB}{128,128,128}
  
  
  \def \globalscale {1.000000}
  \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
    \begin{scope}[line cap=butt,line width=0.0529cm]
      \path[draw=grey,line cap=butt,line width=0.0529cm] (16.4042, -2.1262) .. controls (16.0613, -2.0429) and (15.7151, -1.9651) .. (15.3657, -1.8928) .. controls (15.1133, -1.8406) and (14.8389, -1.7895) .. (14.5426, -1.7394) .. controls (13.6652, -1.5912) and (12.8393, -1.3039) .. (12.065, -0.8774) .. controls (11.9082, -0.7909) and (11.7293, -0.6873) .. (11.5284, -0.5665) .. controls (11.4117, -0.4961) and (11.2662, -0.434) .. (11.0921, -0.3802).. controls (10.6831, -0.2532) and (10.2486, -0.2799) .. (9.8695, -0.4778) .. controls (9.7864, -0.5212) and (9.7049, -0.5685) .. (9.625, -0.6197).. controls (9.1178, -0.9451) and (8.5492, -0.9589) .. (7.9798, -0.7773).. controls (7.8391, -0.7326) and (7.7126, -0.7538) .. (7.58, -0.6681) .. controls (7.382, -0.5398) and (7.1682, -0.5064) .. (6.9387, -0.5678) .. controls (6.835, -0.5955) and (6.7035, -0.6563) .. (6.5442, -0.7501).. controls (5.8798, -1.1411) and (5.1295, -1.4192) .. (4.4183, -1.6454).. controls (3.9558, -1.7926) and (3.3509, -1.9516) .. (2.8093, -2.1159) .. controls (2.0117, -2.3575) and (1.2028, -2.554) .. (0.3826, -2.7054) .. controls (0.2515, -2.7295) and (0.124, -2.7561) .. (0.0, -2.785);
  
  
  
    \end{scope}
    \path[fill=black] (0.8662, -3.6663) -- (0.8665, -3.6737){[rotate=87.8] arc(94.9855:{end_ang}:{radi})}.. controls (0.9835, -3.6811) and (1.0858, -3.6999) .. (1.1933, -3.7095) .. controls (1.597, -3.7446) and (1.9995, -3.7775) .. (2.4006, -3.8081) .. controls (2.7929, -3.8381) and (3.3088, -3.8617) .. (3.9484, -3.8788).. controls (4.3363, -3.8894) and (4.7154, -3.8957) .. (5.0972, -3.9174).. controls (5.284, -3.928) and (5.4713, -3.9312) .. (5.6555, -3.9463) .. controls (6.125, -3.9845) and (6.566, -4.0173) .. (6.9784, -4.0444) .. controls (7.1382, -4.0548) and (7.2947, -4.0637) .. (7.448, -4.0711) .. controls (8.0006, -4.0976) and (8.6091, -4.1152) .. (9.2734, -4.1238) .. controls (9.309, -4.1243) and (9.3465, -4.1251) .. (9.3858, -4.1262) .. controls (10.6745, -4.162) and (11.8891, -4.1956) .. (13.0294, -4.227) .. controls (13.0672, -4.228) and (13.0858, -4.2475) .. (13.0852, -4.2855) -- (13.0847, -4.3132) .. controls (13.0842, -4.3478) and (13.0666, -4.3647) .. (13.0321, -4.3638) .. controls (12.6849, -4.3557) and (12.3405, -4.3483) .. (11.9989, -4.3415) .. controls (11.9768, -4.3412) and (11.9548, -4.3408) .. (11.9327, -4.3402) .. controls (11.3328, -4.3268) and (10.7044, -4.3113) .. (10.0476, -4.2937) .. controls (9.6979, -4.2845) and (9.2923, -4.2744) .. (8.8305, -4.2635) .. controls (8.217, -4.2489) and (7.5248, -4.2224) .. (6.7538, -4.1841) .. controls (6.425, -4.1679) and (6.0906, -4.1379) .. (5.7507, -4.0942) .. controls (5.6549, -4.082) and (5.5185, -4.0775) .. (5.3414, -4.0807).. controls (5.2769, -4.0817) and (5.2115, -4.0693) .. (5.1459, -4.068) .. controls (4.065, -4.0464) and (2.9866, -3.9953) .. (1.9108, -3.9145).. controls (1.5679, -3.8888) and (1.1901, -3.8476) .. (0.8295, -3.8145).. controls (0.6665, -3.7994) and (0.495, -3.8013) .. (0.3387, -3.765) .. controls (0.2898, -3.7536) and (0.2505, -3.7276) .. (0.2207, -3.6872) .. controls (0.2134, -3.6774) and (0.2143, -3.6683) .. (0.2233, -3.66) .. controls (0.2776, -3.6106) and (0.3483, -3.5803) .. (0.4352, -3.569).. controls (1.1621, -3.4745) and (1.8973, -3.3933) .. (2.6204, -3.402) .. controls (2.7644, -3.4038) and (2.9093, -3.4049) .. (3.0551, -3.4055) .. controls (3.682, -3.4079) and (4.3768, -3.4018) .. (5.1395, -3.3872) .. controls (5.2889, -3.3842) and (5.4411, -3.3815) .. (5.5959, -3.379) .. controls (6.038, -3.3721) and (6.4997, -3.3673) .. (6.981, -3.3644).. controls (7.1842, -3.3634) and (7.3583, -3.2359) .. (7.5591, -3.2192) .. controls (7.9403, -3.1878) and (8.346, -3.1627) .. (8.7762, -3.1438) .. controls (9.4749, -3.1131) and (10.0883, -3.1124) .. (10.6164, -3.1417) .. controls (10.9572, -3.1605) and (11.2293, -3.1637) .. (11.4326, -3.1512) .. controls (11.7311, -3.133) and (12.0837, -3.1032) .. (12.4905, -3.0618) .. controls (12.7967, -3.0307) and (13.1791, -3.0221) .. (13.6377, -3.0358) .. controls (14.4348, -3.0596) and (15.2131, -3.1216) .. (15.9726, -3.2216) .. controls (16.0012, -3.2253) and (16.0266, -3.2364) .. (16.0488, -3.2549) .. controls (16.0741, -3.2757) and (16.08, -3.2935) .. (16.0666, -3.3084) .. controls (16.0378, -3.3399) and (16.0042, -3.3539) .. (15.9658, -3.3502) .. controls (15.3094, -3.2867) and (14.6839, -3.2329) .. (14.0893, -3.189) .. controls (13.812, -3.1684) and (13.5296, -3.1625) .. (13.2421, -3.1713) .. controls (12.8135, -3.1843) and (12.4829, -3.2018) .. (12.2502, -3.2237) .. controls (12.0064, -3.2468) and (11.778, -3.2667) .. (11.5649, -3.2835).. controls (11.3943, -3.2967) and (11.2173, -3.2988) .. (11.0471, -3.2912) .. controls (10.7132, -3.2763) and (10.3956, -3.2626) .. (10.0941, -3.2499) .. controls (9.538, -3.2266) and (9.0093, -3.2455) .. (8.5082, -3.3065) .. controls (8.4551, -3.3128) and (8.4085, -3.3118) .. (8.3685, -3.3033) .. controls (8.2992, -3.2885) and (8.2257, -3.2863) .. (8.1481, -3.2967) .. controls (8.1264, -3.2995) and (8.1249, -3.3066) .. (8.1436, -3.3179) .. controls (8.153, -3.3233) and (8.1628, -3.3274) .. (8.1732, -3.33) .. controls (8.2823, -3.3574) and (8.3878, -3.3709) .. (8.49, -3.3705) .. controls (9.1271, -3.3674) and (9.7518, -3.3665) .. (10.3643, -3.3679) .. controls (10.4004, -3.3681) and (10.4183, -3.3861) .. (10.418, -3.4221) -- (10.4177, -3.4502) .. controls (10.4174, -3.4869) and (10.3988, -3.5056) .. (10.3621, -3.5065).. controls (10.2846, -3.5089) and (10.2055, -3.4994) .. (10.1275, -3.4999) .. controls (9.7616, -3.5018) and (9.3822, -3.5002) .. (8.9892, -3.4949) .. controls (8.904, -3.4936) and (8.8246, -3.4929) .. (8.7511, -3.4925).. controls (8.0746, -3.4885) and (7.4112, -3.4822) .. (6.7469, -3.4989) .. controls (6.4045, -3.5073) and (6.0628, -3.5123) .. (5.7216, -3.5139).. controls (5.6811, -3.5139) and (5.6269, -3.5245) .. (5.5793, -3.5245) .. controls (4.8434, -3.5265) and (4.0529, -3.5287) .. (3.2078, -3.5314).. controls (2.7718, -3.5327) and (2.3347, -3.5462) .. (1.8989, -3.5661) .. controls (1.6546, -3.5772) and (1.3114, -3.6094) .. (0.8692, -3.6629) .. controls (0.867, -3.6631) and (0.8661, -3.6642) .. (0.8662, -3.6663) -- cycle;
  
  
  
  
  \end{tikzpicture}
  \end{document}
  ```
  The ```arc(94.9855:{end_ang}:{radi})}``` command produces errors ```Package PGF Math Error: Unknown function 'end_ang' (in 'end_ang')``` and ```Package PGF Math Error: Unknown function 'radi' (in 'radi')``` in LaTeX.

* #### After the fix, this output is returned:
  ``` LaTeX
  \documentclass{article}
  \usepackage[utf8]{inputenc}
  \usepackage{tikz}
  
  \begin{document}
  \definecolor{grey}{RGB}{128,128,128}
  
  
  \def \globalscale {1.000000}
  \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
    \begin{scope}[line cap=butt,line width=0.0529cm]
      \path[draw=grey,line cap=butt,line width=0.0529cm] (16.4042, -2.1262) .. controls (16.0613, -2.0429) and (15.7151, -1.9651) .. (15.3657, -1.8928) .. controls (15.1133, -1.8406) and (14.8389, -1.7895) .. (14.5426, -1.7394) .. controls (13.6652, -1.5912) and (12.8393, -1.3039) .. (12.065, -0.8774) .. controls (11.9082, -0.7909) and (11.7293, -0.6873) .. (11.5284, -0.5665) .. controls (11.4117, -0.4961) and (11.2662, -0.434) .. (11.0921, -0.3802).. controls (10.6831, -0.2532) and (10.2486, -0.2799) .. (9.8695, -0.4778) .. controls (9.7864, -0.5212) and (9.7049, -0.5685) .. (9.625, -0.6197).. controls (9.1178, -0.9451) and (8.5492, -0.9589) .. (7.9798, -0.7773).. controls (7.8391, -0.7326) and (7.7126, -0.7538) .. (7.58, -0.6681) .. controls (7.382, -0.5398) and (7.1682, -0.5064) .. (6.9387, -0.5678) .. controls (6.835, -0.5955) and (6.7035, -0.6563) .. (6.5442, -0.7501).. controls (5.8798, -1.1411) and (5.1295, -1.4192) .. (4.4183, -1.6454).. controls (3.9558, -1.7926) and (3.3509, -1.9516) .. (2.8093, -2.1159) .. controls (2.0117, -2.3575) and (1.2028, -2.554) .. (0.3826, -2.7054) .. controls (0.2515, -2.7295) and (0.124, -2.7561) .. (0.0, -2.785);
  
  
  
    \end{scope}
    \path[fill=black] (0.8662, -3.6663) -- (0.8665, -3.6737){[rotate=87.8] arc(94.9855:183.7884:0.0106 and 0.0103)}.. controls (0.9835, -3.6811) and (1.0858, -3.6999) .. (1.1933, -3.7095) .. controls (1.597, -3.7446) and (1.9995, -3.7775) .. (2.4006, -3.8081) .. controls (2.7929, -3.8381) and (3.3088, -3.8617) .. (3.9484, -3.8788).. controls (4.3363, -3.8894) and (4.7154, -3.8957) .. (5.0972, -3.9174).. controls (5.284, -3.928) and (5.4713, -3.9312) .. (5.6555, -3.9463) .. controls (6.125, -3.9845) and (6.566, -4.0173) .. (6.9784, -4.0444) .. controls (7.1382, -4.0548) and (7.2947, -4.0637) .. (7.448, -4.0711) .. controls (8.0006, -4.0976) and (8.6091, -4.1152) .. (9.2734, -4.1238) .. controls (9.309, -4.1243) and (9.3465, -4.1251) .. (9.3858, -4.1262) .. controls (10.6745, -4.162) and (11.8891, -4.1956) .. (13.0294, -4.227) .. controls (13.0672, -4.228) and (13.0858, -4.2475) .. (13.0852, -4.2855) -- (13.0847, -4.3132) .. controls (13.0842, -4.3478) and (13.0666, -4.3647) .. (13.0321, -4.3638) .. controls (12.6849, -4.3557) and (12.3405, -4.3483) .. (11.9989, -4.3415) .. controls (11.9768, -4.3412) and (11.9548, -4.3408) .. (11.9327, -4.3402) .. controls (11.3328, -4.3268) and (10.7044, -4.3113) .. (10.0476, -4.2937) .. controls (9.6979, -4.2845) and (9.2923, -4.2744) .. (8.8305, -4.2635) .. controls (8.217, -4.2489) and (7.5248, -4.2224) .. (6.7538, -4.1841) .. controls (6.425, -4.1679) and (6.0906, -4.1379) .. (5.7507, -4.0942) .. controls (5.6549, -4.082) and (5.5185, -4.0775) .. (5.3414, -4.0807).. controls (5.2769, -4.0817) and (5.2115, -4.0693) .. (5.1459, -4.068) .. controls (4.065, -4.0464) and (2.9866, -3.9953) .. (1.9108, -3.9145).. controls (1.5679, -3.8888) and (1.1901, -3.8476) .. (0.8295, -3.8145).. controls (0.6665, -3.7994) and (0.495, -3.8013) .. (0.3387, -3.765) .. controls (0.2898, -3.7536) and (0.2505, -3.7276) .. (0.2207, -3.6872) .. controls (0.2134, -3.6774) and (0.2143, -3.6683) .. (0.2233, -3.66) .. controls (0.2776, -3.6106) and (0.3483, -3.5803) .. (0.4352, -3.569).. controls (1.1621, -3.4745) and (1.8973, -3.3933) .. (2.6204, -3.402) .. controls (2.7644, -3.4038) and (2.9093, -3.4049) .. (3.0551, -3.4055) .. controls (3.682, -3.4079) and (4.3768, -3.4018) .. (5.1395, -3.3872) .. controls (5.2889, -3.3842) and (5.4411, -3.3815) .. (5.5959, -3.379) .. controls (6.038, -3.3721) and (6.4997, -3.3673) .. (6.981, -3.3644).. controls (7.1842, -3.3634) and (7.3583, -3.2359) .. (7.5591, -3.2192) .. controls (7.9403, -3.1878) and (8.346, -3.1627) .. (8.7762, -3.1438) .. controls (9.4749, -3.1131) and (10.0883, -3.1124) .. (10.6164, -3.1417) .. controls (10.9572, -3.1605) and (11.2293, -3.1637) .. (11.4326, -3.1512) .. controls (11.7311, -3.133) and (12.0837, -3.1032) .. (12.4905, -3.0618) .. controls (12.7967, -3.0307) and (13.1791, -3.0221) .. (13.6377, -3.0358) .. controls (14.4348, -3.0596) and (15.2131, -3.1216) .. (15.9726, -3.2216) .. controls (16.0012, -3.2253) and (16.0266, -3.2364) .. (16.0488, -3.2549) .. controls (16.0741, -3.2757) and (16.08, -3.2935) .. (16.0666, -3.3084) .. controls (16.0378, -3.3399) and (16.0042, -3.3539) .. (15.9658, -3.3502) .. controls (15.3094, -3.2867) and (14.6839, -3.2329) .. (14.0893, -3.189) .. controls (13.812, -3.1684) and (13.5296, -3.1625) .. (13.2421, -3.1713) .. controls (12.8135, -3.1843) and (12.4829, -3.2018) .. (12.2502, -3.2237) .. controls (12.0064, -3.2468) and (11.778, -3.2667) .. (11.5649, -3.2835).. controls (11.3943, -3.2967) and (11.2173, -3.2988) .. (11.0471, -3.2912) .. controls (10.7132, -3.2763) and (10.3956, -3.2626) .. (10.0941, -3.2499) .. controls (9.538, -3.2266) and (9.0093, -3.2455) .. (8.5082, -3.3065) .. controls (8.4551, -3.3128) and (8.4085, -3.3118) .. (8.3685, -3.3033) .. controls (8.2992, -3.2885) and (8.2257, -3.2863) .. (8.1481, -3.2967) .. controls (8.1264, -3.2995) and (8.1249, -3.3066) .. (8.1436, -3.3179) .. controls (8.153, -3.3233) and (8.1628, -3.3274) .. (8.1732, -3.33) .. controls (8.2823, -3.3574) and (8.3878, -3.3709) .. (8.49, -3.3705) .. controls (9.1271, -3.3674) and (9.7518, -3.3665) .. (10.3643, -3.3679) .. controls (10.4004, -3.3681) and (10.4183, -3.3861) .. (10.418, -3.4221) -- (10.4177, -3.4502) .. controls (10.4174, -3.4869) and (10.3988, -3.5056) .. (10.3621, -3.5065).. controls (10.2846, -3.5089) and (10.2055, -3.4994) .. (10.1275, -3.4999) .. controls (9.7616, -3.5018) and (9.3822, -3.5002) .. (8.9892, -3.4949) .. controls (8.904, -3.4936) and (8.8246, -3.4929) .. (8.7511, -3.4925).. controls (8.0746, -3.4885) and (7.4112, -3.4822) .. (6.7469, -3.4989) .. controls (6.4045, -3.5073) and (6.0628, -3.5123) .. (5.7216, -3.5139).. controls (5.6811, -3.5139) and (5.6269, -3.5245) .. (5.5793, -3.5245) .. controls (4.8434, -3.5265) and (4.0529, -3.5287) .. (3.2078, -3.5314).. controls (2.7718, -3.5327) and (2.3347, -3.5462) .. (1.8989, -3.5661) .. controls (1.6546, -3.5772) and (1.3114, -3.6094) .. (0.8692, -3.6629) .. controls (0.867, -3.6631) and (0.8661, -3.6642) .. (0.8662, -3.6663) -- cycle;
  
  
  
  
  \end{tikzpicture}
  \end{document}
  ```
  And now the command ```arc(94.9855:183.7884:0.0106 and 0.0103)``` contains the correct values.
# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
