### PR TITLE
FIX: arc direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 - Adding info about the dependencies and how to contribute in the README
+- Adding test for the arc direction
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 - Fixing the latex build of the docs
+- Fixing some arc were not rendered correctly by tikz
 ### Security
 
 ## v3.1.0 - 19/05/2024

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -164,6 +164,12 @@ class TestCompleteFiles(unittest.TestCase):
             filename, self, texmode="attribute", texmode_attribute="data-texmode"
         )
 
+    def test_arc_direction(self):
+        """Test per SVG object texmode with attribute"""
+        # Exemple taken from svg of the flag of the state of California
+        filename = "R_letter_with_arc"
+        create_test_from_filename(filename, self)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testfiles/R_letter_with_arc.svg
+++ b/tests/testfiles/R_letter_with_arc.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="210mm"
+   height="297mm"
+   viewBox="0 0 210 297"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   sodipodi:docname="R_lettere.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="3.0893886"
+     inkscape:cx="105.19881"
+     inkscape:cy="115.71869"
+     inkscape:window-width="1918"
+     inkscape:window-height="1150"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       class="c"
+       d="M 11.390311,19.57934 H 8.9958322 V 6.3501736 h 5.1244498 a 1.3469937,1.3469937 0 0 1 0.981604,0.4016375 1.3107458,1.3107458 0 0 1 0.407194,0.968375 v 4.8191209 a 1.2871979,1.2871979 0 0 1 -0.61304,1.134004 1.2877271,1.2877271 0 0 1 0.61304,1.134004 v 3.411273 a 1.27,1.27 0 0 0 0.718344,1.190625 q 0.07646,0.0471 0.07646,0.09419 a 0.06720417,0.06720417 0 0 1 -0.07646,0.07593 H 14.590182 A 1.3385271,1.3385271 0 0 1 13.61334,19.182465 1.3022792,1.3022792 0 0 1 13.211174,18.218853 v -3.553354 h -1.820069 z m 0,-6.992673 H 13.21038 V 8.7123736 h -1.820069 z"
+       id="path8"
+       style="fill:#584528;stroke-width:0.264583" />
+  </g>
+</svg>

--- a/tests/testfiles/R_letter_with_arc.tex
+++ b/tests/testfiles/R_letter_with_arc.tex
@@ -1,0 +1,18 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{c584528}{RGB}{88,69,40}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
+  \path[fill=c584528,line width=0.0265cm] (1.139, 27.7421) -- (0.8996, 27.7421) -- (0.8996, 29.065) -- (1.412, 29.065)arc(269.0684:315.4369:0.1347 and -0.1347)arc(-46.43000000000001:0.8173:0.1311 and -0.1311) -- (1.5509, 28.4461)arc(-1.6533999999999764:58.4445:0.1287 and -0.1287)arc(-58.43090000000001:1.6398:0.1288 and -0.1288) -- (1.5509, 27.8781)arc(182.0888:115.7033:0.127 and -0.127) .. controls (1.6278, 27.7559) and (1.6304, 27.7528) .. (1.6304, 27.7497)arc(-8.094499999999982:98.4931:0.0067 and -0.0067) -- (1.459, 27.7421)arc(88.9159:135.3056:0.1339 and -0.1339)arc(133.7122:180.9811:0.1302 and -0.1302) -- (1.3211, 28.2335) -- (1.1391, 28.2335) -- cycle(1.139, 28.4413) -- (1.321, 28.4413) -- (1.321, 28.8288) -- (1.139, 28.8288) -- cycle;
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

Pgf 2.0 does not handle well angle not in the range [-360, 360]. the angle of an arc will now be sanitize (with a new function) to put them in this range.

Before:
![screenshot_20240828_075347](https://github.com/user-attachments/assets/4af6b717-0b76-4460-aaab-d666a1f4beb0)


After:
![screenshot_20240828_075259](https://github.com/user-attachments/assets/4ac056d9-1407-43ec-930d-4625e7bb7faf)


Fixes #208 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Took a portion of the faulty svg and test that it renders correctly.
Added a new test


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
