### PR TITLE
ADD: support for S letter command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Adding support for the S command letter in svg
 ### Changed
 ### Deprecated
 ### Removed

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1124,8 +1124,9 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
                 s += f" -- {self.coord_to_tz(tparams[0])}"
 
             # cubic bezier curve
-            elif letter == "C":
+            elif letter in ["C", "S"]:
                 s += f".. controls {self.coord_to_tz(tparams[0])} and {self.coord_to_tz(tparams[1])} .. {self.coord_to_tz(tparams[2])}"
+                # s_point = 2 * tparams[2] - tparams[1]
 
             # quadratic bezier curve
             elif letter == "Q":

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -169,6 +169,13 @@ class TestCompleteFiles(unittest.TestCase):
         # Exemple taken from svg of the flag of the state of California
         filename = "R_letter_with_arc"
         create_test_from_filename(filename, self)
+        c
+
+    def test_arc_direction(self):
+        """Test svg with S command inside it"""
+        # Exemple taken from svg of the flag of the state of California
+        filename = "s_command_letter"
+        create_test_from_filename(filename, self)
 
 
 if __name__ == "__main__":

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -169,9 +169,8 @@ class TestCompleteFiles(unittest.TestCase):
         # Exemple taken from svg of the flag of the state of California
         filename = "R_letter_with_arc"
         create_test_from_filename(filename, self)
-        c
 
-    def test_arc_direction(self):
+    def test_s_command(self):
         """Test svg with S command inside it"""
         # Exemple taken from svg of the flag of the state of California
         filename = "s_command_letter"

--- a/tests/testfiles/s_command_letter.svg
+++ b/tests/testfiles/s_command_letter.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 477.66 72.07"
+   version="1.1"
+   id="svg12"
+   sodipodi:docname="dynamic_web.svg"
+   inkscape:version="1.3.2 (1:1.3.2+202311252150+091e20ef0f)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.3866041"
+     inkscape:cx="306.14362"
+     inkscape:cy="213.47117"
+     inkscape:window-width="1918"
+     inkscape:window-height="1173"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g9" />
+  <defs
+     id="defs1">
+    <style
+       id="style1">.d{fill:#003cff;}</style>
+  </defs>
+  <g
+     id="a" />
+  <g
+     id="g2">
+    <g
+       id="g1">
+      <path
+         class="d"
+         d="m 251.39,10.97 c -1.49,0 -2.79,-0.53 -3.88,-1.6 -1.09,-1.07 -1.64,-2.37 -1.64,-3.92 0,-1.55 0.55,-2.77 1.64,-3.84 C 248.6,0.54 249.9,0 251.39,0 c 1.49,0 2.84,0.54 3.88,1.61 1.04,1.07 1.57,2.35 1.57,3.84 0,1.49 -0.52,2.85 -1.57,3.92 -1.04,1.07 -2.34,1.6 -3.88,1.6 z m -4.1,45.43 V 19.1 h 8.2 v 37.3 z"
+         id="path1"
+         style="fill:#ff5555" />
+    </g>
+  </g>
+  <g
+     id="b">
+    <g
+       id="c">
+      <g
+         id="g9">
+        <path
+           class="d"
+           d="M 251.39,10.97 c -1.49,0-2.79-.53-3.88-1.6-1.09-1.07-1.64-2.37-1.64-3.92 s 0.55-2.77,1.64-3.84 c 1.09-1.07,2.39-1.61,3.88-1.61 s 2.84,.54,3.88,1.61 c 1.04,1.07,1.57,2.35,1.57,3.84 s -0.52,2.85-1.57,3.92 c -1.04,1.07-2.34,1.6-3.88,1.6 Z"
+           id="path6" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/tests/testfiles/s_command_letter.tex
+++ b/tests/testfiles/s_command_letter.tex
@@ -1,0 +1,23 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{cff5555}{RGB}{255,85,85}
+\definecolor{c003cff}{RGB}{0,60,255}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
+  \path[fill=cff5555] (6.6514, -0.2902).. controls (6.6119, -0.2902) and (6.5775, -0.2762) .. (6.5487, -0.2479).. controls (6.5199, -0.2196) and (6.5053, -0.1852) .. (6.5053, -0.1442).. controls (6.5053, -0.1032) and (6.5199, -0.0709) .. (6.5487, -0.0426).. controls (6.5775, -0.0143) and (6.6119, 0.0) .. (6.6514, 0.0).. controls (6.6908, 0.0) and (6.7265, -0.0143) .. (6.754, -0.0426).. controls (6.7815, -0.0709) and (6.7956, -0.1048) .. (6.7956, -0.1442).. controls (6.7956, -0.1836) and (6.7818, -0.2196) .. (6.754, -0.2479).. controls (6.7265, -0.2762) and (6.6921, -0.2902) .. (6.6514, -0.2902) -- cycle(6.5429, -1.4923) -- (6.5429, -0.5054) -- (6.7598, -0.5054) -- (6.7598, -1.4923) -- cycle;
+
+
+
+  \path[fill=c003cff] (6.6514, -0.2902).. controls (6.6119, -0.2902) and (6.5775, -0.2762) .. (6.5487, -0.2479).. controls (6.5199, -0.2196) and (6.5053, -0.1852) .. (6.5053, -0.1442).. controls (6.5053, -0.1032) and (6.5199, -0.0709) .. (6.5487, -0.0426).. controls (6.5775, -0.0143) and (6.6119, -0.0) .. (6.6514, -0.0).. controls (6.6908, -0.0) and (6.7265, -0.0143) .. (6.754, -0.0426).. controls (6.7815, -0.0709) and (6.7956, -0.1048) .. (6.7956, -0.1442).. controls (6.7956, -0.1836) and (6.7818, -0.2196) .. (6.754, -0.2479).. controls (6.7265, -0.2762) and (6.6921, -0.2902) .. (6.6514, -0.2902) -- cycle;
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

S command were not supported in SVG2tikz. Inkex seems to do all the work to compute the points for the S command as for a C command. S and C commands are using the same logic 

Fixes #210 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on the svg of #210 
New test using part of the logo included in the code


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
