### PR TITLE
FIX: get_shape_inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix `get-shape-inside-function` with new inkex
 ### Security
 
 ## v3.2.1 - 24/09/2024

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -819,7 +819,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         url = style.get("shape-inside")
         if url is None:
             return None
-        shape = inkex.properties.match_url_and_return_element(url, self.svg)
+        shape = self.svg.getElementById(url)
         return shape
 
     def style_to_tz(self, node=None):  # pylint: disable=too-many-branches


### PR DESCRIPTION
# Description

With inkex 1.4, the properties were updated. The function `match_url_and_return_element` does not exist anymore

Fixes #212 

## Type of change


- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Regular test suite + testing the provided svg


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
