### PR TITLE
Fix install dir for macOS

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,7 +45,7 @@ Linux
     ``/usr/share/inkscape/extensions`` *or* ``~/.config/inkscape/extensions/``
 
 Mac
-    ``/Applications/Inkscape.app/Contents/Resources/extensions`` *or* ``~/.config/inkscape/extensions/``
+    ``/Applications/Inkscape.app/Contents/Resources/share/inkscape/extensions/`` *or* ``~/Library/Application Support/org.inkscape.Inkscape/config/inkscape/extensions/``
 
 
 Additionally the extension has the following dependencies:


### PR DESCRIPTION
# Description

The existing installation directories for macOS do not actually exist and are not recognized by Inkscape. I have updated the documentation to provide clearer instructions.

I couldn’t determine from which version of macOS or Inkscape the issue started, but in the latest versions macOS 15.3.1 and Inkscape 1.4, it should work.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] My code follows the style guidelines of this project (black/pylint)
- [ ] I have updated the changelog with the corresponding changes
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
