### PR TITLE
Multiple radius corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Deploy on the github pages
 - Update lxml version to work with python 3.13
+- A rectangle with two corner radius will use the smallest one
 ### Security
 
 ## v3.3.0 - 12/01/2025

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Contents
    inkscapeguide.rst
    cmdlineguide.rst
    moduleguide.rst
+   limitation.rst
    contribute.rst
 
 Indices and tables

--- a/docs/limitation.rst
+++ b/docs/limitation.rst
@@ -1,0 +1,6 @@
+Limitation
+=======
+
+Here is a list of current limitations of the code:
+
+- A rectangle with two differents corner radius for the x and y coordinate will use only the smallest one of the two. To have the correct representation of the shape convert the rectangle to a path in inkscape.

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1197,7 +1197,10 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         """Extract shape data from node"""
         options = []
         if node.TAG == "rect":
-            inset = node.rx or node.ry
+            inset = min(node.rx, node.ry)
+            if inset < 1e-5:
+                inset = max(node.rx, node.ry)
+
             x = node.left
             y = node.top
             corner_a = self.convert_unit_coord(Vector2d(x, y))

--- a/tests/testfiles/rectangle.tex
+++ b/tests/testfiles/rectangle.tex
@@ -14,7 +14,7 @@
 
 
 
-  \path[draw=black,line cap=,line width=0.2cm,rounded corners=1.4343cm] (0.7985, 25.8962) rectangle (5.0753, 24.0665);
+  \path[draw=black,line cap=,line width=0.2cm,rounded corners=0.6627cm] (0.7985, 25.8962) rectangle (5.0753, 24.0665);
 
 
 

--- a/tests/testfiles/rectangle_wrap.tex
+++ b/tests/testfiles/rectangle_wrap.tex
@@ -15,7 +15,7 @@
 
 
 
-  \path[draw=black,line cap=,line width=0.2cm,rounded corners=1.4343cm] (0.7985,
+  \path[draw=black,line cap=,line width=0.2cm,rounded corners=0.6627cm] (0.7985,
    25.8962) rectangle (5.0753, 24.0665);
 
 


### PR DESCRIPTION
# Description

Corner with two radii are not supported in tikz. 
This PR, force to use the smallest one of the two

Fixes #193 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested visually with `rectangle.svg`


# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
