### PR TITLE
Extended the _do_linux_clipboard function to accommodate wayland clipboard.

### DIFF
--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -157,6 +157,11 @@ def copy_to_clipboard(text):  # pragma: no cover
 
         xsel_cmd = ["xsel"]
         success = _call_command(xsel_cmd, text)
+        if success:
+            return True
+
+        wl_cmd = ["wl-copy"]
+        success = _call_command(wl_cmd, text)
         return success
 
     def _do_osx_clipboard(text):


### PR DESCRIPTION
# Description

The export to clipboard functionality was not implemented for wl-copy command used on wayland. The _do_linux_clipboard function in tikz_export.py was slightly extended to accommodate this command.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
As the changes made are very small, they were copied to my local installation of tikz_export.py under Inkscape's extensions directory. The copy to clipboard functionality seemed to work without any issues after this on my installation of Inkscape.


# Checklist:

- [ ] My code follows the style guidelines of this project (black/pylint)
- [ ] I have performed a self-review of my code