### PR TITLE
FIX: S command with non C/S previous command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+- S command were not correctly handled in the path if the previous command were not an S or a C
 ### Security
 
 ## v3.3.1 - 24/05/2025

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -1110,11 +1110,14 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         """
         s = ""
 
+        current_pos = Vector2d(0.0, 0.0)
+        last_command = None
+
         for command in path.proxy_iterator():
+            tparams = self.convert_unit_coords(command.control_points)
+
             letter = command.letter.upper()
 
-            # transform coords
-            tparams = self.convert_unit_coords(command.control_points)
             # moveto
             if letter == "M":
                 s += self.coord_to_tz(tparams[0])
@@ -1125,8 +1128,12 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
 
             # cubic bezier curve
             elif letter in ["C", "S"]:
-                s += f".. controls {self.coord_to_tz(tparams[0])} and {self.coord_to_tz(tparams[1])} .. {self.coord_to_tz(tparams[2])}"
-                # s_point = 2 * tparams[2] - tparams[1]
+                cp_1 = tparams[0]
+
+                if letter == "S" and last_command not in ["C", "S"]:
+                    cp_1 = current_pos
+
+                s += f".. controls {self.coord_to_tz(cp_1)} and {self.coord_to_tz(tparams[1])} .. {self.coord_to_tz(tparams[2])}"
 
             # quadratic bezier curve
             elif letter == "Q":
@@ -1191,6 +1198,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
                     s += f"arc({start_ang}:{end_ang}:{radi})"
             # Get the last position
             current_pos = tparams[-1]
+            last_command = letter
         return s
 
     def _handle_shape(self, node):

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -176,6 +176,12 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "s_command_letter"
         create_test_from_filename(filename, self)
 
+    def test_s_command(self):
+        """Test svg with S command inside it without previous bezier curve"""
+        # Example taken from svg of #232
+        filename = "s_command_no_previous_bezier"
+        create_test_from_filename(filename, self)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testfiles/s_command_no_previous_bezier.svg
+++ b/tests/testfiles/s_command_no_previous_bezier.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Layer_1"
+   data-name="Layer 1"
+   width="6.45in"
+   height="7.52in"
+   viewBox="0 0 464.24 541.79"
+   version="1.1"
+   sodipodi:docname="bar.svg"
+   inkscape:version="1.4.1 (1:1.4.1+202503302257+93de688d07)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview42"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="in"
+     showgrid="false"
+     inkscape:zoom="3.2330452"
+     inkscape:cx="243.73306"
+     inkscape:cy="317.81182"
+     inkscape:window-width="2558"
+     inkscape:window-height="1413"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <defs
+     id="defs1">
+    <style
+       id="style1">
+      .cls-1 {
+        fill: #eeece2;
+      }
+
+      .cls-2 {
+        fill: #ac2424;
+      }
+
+      .cls-3 {
+        fill: #cfa33b;
+      }
+    </style>
+  </defs>
+  <path
+     class="cls-1"
+     d="M 152.44,341.46 c 0,2.63-20.71-14.37-20.97-20.06-.26-5.69,0-169.91,0-169.91 h 100 s 0,187.33,0,189.97 Z"
+     id="path37" />
+</svg>

--- a/tests/testfiles/s_command_no_previous_bezier.tex
+++ b/tests/testfiles/s_command_no_previous_bezier.tex
@@ -1,0 +1,18 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{ceeece2}{RGB}{238,236,226}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
+  \path[fill=ceeece2] (5.3796, 7.0696).. controls (5.3796, 6.9768) and (4.6487, 7.5767) .. (4.6396, 7.7775).. controls (4.6304, 7.9783) and (4.6396, 13.7737) .. (4.6396, 13.7737) -- (8.1686, 13.7737).. controls (8.1686, 13.7737) and (8.1686, 7.1628) .. (8.1686, 7.0696) -- cycle;
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

For a `S` command, if the previous command is not an `S` or a `C` then the first control point should be the same as the current point.

Fixes #232 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

New test based on the problematic svg

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
