### PR TITLE
Option to render paths using the svg.path library in PGF/TikZ.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Option to use svg.path instead of converting to pgf's standard path operations for paths.
 ### Changed
 ### Deprecated
 ### Removed

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -569,9 +569,10 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
         )
         self._add_booloption(
             parser, 
-            "--svg_paths", 
+            "--svg-paths",
+            dest="svg_paths", 
             default=False, 
-            help="Use SVG.path library for paths."
+            help="Use svg.path library for paths."
         )
         if not self.inkscape_mode:
             parser.add_argument(

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -213,6 +213,7 @@ STANDALONE_TEMPLATE = (
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 \usepackage{tikz}
+%(svgpath)s
 %(cropcode)s
 \begin{document}
 %(colorcode)s
@@ -444,6 +445,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             verbose=False,
             texmode="escape",
             markings="ignore",
+            svg_paths=False,
         )
         parser.add_argument(
             "--codeoutput",
@@ -564,6 +566,12 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             type=float,
             default=1,
             help="Apply scale to resulting image, defaults to 1.0",
+        )
+        self._add_booloption(
+            parser, 
+            "--svg_paths", 
+            default=False, 
+            help="Use SVG.path library for paths."
         )
         if not self.inkscape_mode:
             parser.add_argument(
@@ -1372,7 +1380,10 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             if node.TAG == "path":
                 optionscode = options_to_str(goptions)
 
-                pathcode = f"\\path{optionscode} {self.convert_path_to_tikz(node.path)}"
+                if self.options.svg_paths:
+                    pathcode = f"\\path{optionscode} svg {{{node.path}}}"
+                else:
+                    pathcode = f"\\path{optionscode} {self.convert_path_to_tikz(node.path)}"
 
             elif node.TAG in LIST_OF_SHAPES:
                 # Add indent
@@ -1469,6 +1480,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
                 "cropcode": cropcode,
                 "gradientcode": self.gradient_code,
                 "scale": self.options.scale,
+                "svgpath": "\\usetikzlibrary{{svg.path}}" if self.options.svg_paths else "",
             }
         elif codeoutput == "figonly":
             output = FIG_TEMPLATE % {

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -213,8 +213,7 @@ STANDALONE_TEMPLATE = (
 \documentclass{article}
 \usepackage[utf8]{inputenc}
 \usepackage{tikz}
-%(svgpath)s
-%(cropcode)s
+%(svgpath)s%(cropcode)s
 \begin{document}
 %(colorcode)s
 %(gradientcode)s
@@ -1481,7 +1480,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
                 "cropcode": cropcode,
                 "gradientcode": self.gradient_code,
                 "scale": self.options.scale,
-                "svgpath": "\\usetikzlibrary{{svg.path}}" if self.options.svg_paths else "",
+                "svgpath": "\\usetikzlibrary{{svg.path}}\n" if self.options.svg_paths else "",
             }
         elif codeoutput == "figonly":
             output = FIG_TEMPLATE % {

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -572,7 +572,7 @@ class TikZPathExporter(inkex.Effect, inkex.EffectExtension):
             "--svg-paths",
             dest="svg_paths", 
             default=False, 
-            help="Use svg.path library for paths."
+            help="Use TikZ/PGF svg.path library for paths instead of converting to standard path operations"
         )
         if not self.inkscape_mode:
             parser.add_argument(

--- a/svg2tikz/tikz_export_effect.inx
+++ b/svg2tikz/tikz_export_effect.inx
@@ -19,6 +19,7 @@
       <param name="wrap" type="boolean" gui-text="Wrap paths" gui-description="Wrap the path">true</param>
       <param name="indent" type="boolean" gui-text="Indent groups" gui-description="Indent the tikz code">true</param>
       <param name="round-number" type="int" min="0" value="4" gui-text="Number of decimal" gui-description="Number of significative number after the decimal">1</param>
+      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use pgf's own SVG path parser on paths instead of converting to standard path operations">false</param>
     <separator />
     <label appearance="header">Modification</label>
       <param name="output-unit" type="optiongroup" appearance="combo" gui-text="output unit used in the tikz code">

--- a/svg2tikz/tikz_export_effect.inx
+++ b/svg2tikz/tikz_export_effect.inx
@@ -19,7 +19,7 @@
       <param name="wrap" type="boolean" gui-text="Wrap paths" gui-description="Wrap the path">true</param>
       <param name="indent" type="boolean" gui-text="Indent groups" gui-description="Indent the tikz code">true</param>
       <param name="round-number" type="int" min="0" value="4" gui-text="Number of decimal" gui-description="Number of significative number after the decimal">1</param>
-      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use pgf's own SVG path parser on paths instead of converting to standard path operations">false</param>
+      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use the TikZ/PGF SVG path parser on paths instead of converting to standard path operations">false</param>
     <separator />
     <label appearance="header">Modification</label>
       <param name="output-unit" type="optiongroup" appearance="combo" gui-text="output unit used in the tikz code">

--- a/svg2tikz/tikz_export_output.inx
+++ b/svg2tikz/tikz_export_output.inx
@@ -15,7 +15,7 @@
       <param name="wrap" type="boolean" gui-text="Wrap paths" gui-description="Wrap the path">true</param>
       <param name="indent" type="boolean" gui-text="Indent groups" gui-description="Indent the tikz code">true</param>
       <param name="round-number" type="int" min="0" value="4" gui-text="Number of decimal" gui-description="Number of significative number after the decimal">1</param>
-      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use pgf's own SVG path parser on paths instead of converting to standard path operations">false</param>
+      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use the TikZ/PGF SVG path parser on paths instead of converting to standard path operations">false</param>
     <separator />
     <label appearance="header">Modification</label>
       <param name="output-unit" type="optiongroup" appearance="combo" gui-text="output unit used in the tikz code">

--- a/svg2tikz/tikz_export_output.inx
+++ b/svg2tikz/tikz_export_output.inx
@@ -15,6 +15,7 @@
       <param name="wrap" type="boolean" gui-text="Wrap paths" gui-description="Wrap the path">true</param>
       <param name="indent" type="boolean" gui-text="Indent groups" gui-description="Indent the tikz code">true</param>
       <param name="round-number" type="int" min="0" value="4" gui-text="Number of decimal" gui-description="Number of significative number after the decimal">1</param>
+      <param name="svg-paths" type="boolean" gui-text="Use svg.path instead of path operations" gui-description="Use pgf's own SVG path parser on paths instead of converting to standard path operations">false</param>
     <separator />
     <label appearance="header">Modification</label>
       <param name="output-unit" type="optiongroup" appearance="combo" gui-text="output unit used in the tikz code">

--- a/tests/test_svg2tikz.py
+++ b/tests/test_svg2tikz.py
@@ -142,6 +142,7 @@ class MarkersTest(unittest.TestCase):
         )
         self.assertTrue("->" in code, f'code="{code}"')
 
+
 class SVGPathTest(unittest.TestCase):
     """Test class for SVG path mode"""
 
@@ -149,6 +150,7 @@ class SVGPathTest(unittest.TestCase):
         """Test when SVG path mode is used"""
         code = convert_file(StringIO(SVG_2_PATH), svg_paths=True)
         self.assertTrue("svg" in code)
+
 
 class CommandlineModule(unittest.TestCase):
     """

--- a/tests/test_svg2tikz.py
+++ b/tests/test_svg2tikz.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + "/../")
 # pylint: disable=wrong-import-position
 from svg2tikz import convert_file, convert_svg
 from tests.common import (
+    SVG_2_PATH,
     SVG_2_RECT,
     SVG_3_RECT,
     SVG_ARROW,
@@ -141,6 +142,13 @@ class MarkersTest(unittest.TestCase):
         )
         self.assertTrue("->" in code, f'code="{code}"')
 
+class SVGPathTest(unittest.TestCase):
+    """Test class for SVG path mode"""
+
+    def test_svg_path_mode(self):
+        """Test when SVG path mode is used"""
+        code = convert_file(StringIO(SVG_2_PATH), svg_paths=True)
+        self.assertTrue("svg" in code)
 
 class CommandlineModule(unittest.TestCase):
     """


### PR DESCRIPTION
# Description

Gives the option to use the PGF/TikZ `svg.path` library to render paths instead of converting them to path operations. Sometimes this works better than conversion for specific geometry. This can be enabled by using the `--svg-paths` command line switch or the appropriate checkbox in Inkscape.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] `SVGPathTest` class in `test_svg2tikz.py` with `test_svg_path_mode` method. Checks to see if `svg` is in the PGF/TikZ syntax as defined [here](https://tikz.dev/tikz-paths#pgf.svg).

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
