### PR TITLE
Options for sub/superscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Option to use svg.path instead of converting to pgf's standard path operations for paths.
+- Option to export subscript to latex code
 ### Changed
 ### Deprecated
 ### Removed

--- a/pylintrc
+++ b/pylintrc
@@ -434,7 +434,8 @@ disable=raw-checker-failed,
         superfluous-parens,
         mixed-line-endings,
         unexpected-line-ending-format,
-        fixme
+        fixme,
+        anomalous-backslash-in-string,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -460,7 +460,6 @@ def get_text_latex(node: inkex.TextElement, sep="", insert_math_delim=False) -> 
         if base_shift is None:
             closing_stack.append("")
         elif base_shift in ["sub", "super"]:
-
             if not inside_math and insert_math_delim:
                 result.append(r"\(")
 

--- a/svg2tikz/tikz_export.py
+++ b/svg2tikz/tikz_export.py
@@ -401,6 +401,7 @@ def options_to_str(options: list) -> str:
     """
     return f"[{','.join(options)}]" if len(options) > 0 else ""
 
+
 # pylint: disable=too-many-locals
 def get_text_latex(node: inkex.TextElement, sep="", insert_math_delim=False) -> str:
     """

--- a/svg2tikz/tikz_export_effect.inx
+++ b/svg2tikz/tikz_export_effect.inx
@@ -43,6 +43,10 @@
         <option value="math">Math</option>
         <option value="attribute">Defined by attribute</option>
       </param>
+      <param name="subsup-mode" type="optiongroup" gui-text="Sub/superscript interpretation mode" gui-description="How should it be parsed">
+        <option value="ascii">ASCII</option>
+        <option value="latex">Latex</option>
+      </param>
       <param name="texmode-attribute" type="string" gui-text="Texmode SVG attribute" gui-description="The text interpretation mode will be defined per SVG object by an attribute with this name."></param>
       <param name="notext" type="boolean" gui-text="Ignore the text" gui-description="The text will not be included in the figure">false</param>
     <separator />

--- a/svg2tikz/tikz_export_output.inx
+++ b/svg2tikz/tikz_export_output.inx
@@ -39,6 +39,10 @@
         <option value="math">Math</option>
         <option value="attribute">Defined by attribute</option>
       </param>
+      <param name="subsup-mode" type="optiongroup" gui-text="Sub/superscript interpretation mode" gui-description="How should it be parsed">
+        <option value="ascii">ASCII</option>
+        <option value="latex">Latex</option>
+      </param>
       <param name="texmode-attribute" type="string" gui-text="Texmode SVG attribute" gui-description="The text interpretation mode will be defined per SVG object by an attribute with this name."></param>
       <param name="notext" type="boolean" gui-text="Ignore the text" gui-description="The text will not be included in the figure">false</param>
     <separator />

--- a/tests/test_complete_files.py
+++ b/tests/test_complete_files.py
@@ -176,11 +176,31 @@ class TestCompleteFiles(unittest.TestCase):
         filename = "s_command_letter"
         create_test_from_filename(filename, self)
 
-    def test_s_command(self):
+    def test_s_command_no_previous_bezier(self):
         """Test svg with S command inside it without previous bezier curve"""
         # Example taken from svg of #232
         filename = "s_command_no_previous_bezier"
         create_test_from_filename(filename, self)
+
+    def test_subsup_mode_ascii(self):
+        """Test subsup_mode ascii"""
+        filename = "sub_superscript"
+        create_test_from_filename(
+            filename,
+            self,
+            filename_output="sub_superscript_ascii",
+        )
+
+    def test_subsup_mode_latex(self):
+        """Test subsup_mode latex"""
+        filename = "sub_superscript"
+        create_test_from_filename(
+            filename,
+            self,
+            filename_output="sub_superscript_latex",
+            subsup_mode="latex",
+            texmode="raw",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_svg2tikz.py
+++ b/tests/test_svg2tikz.py
@@ -96,11 +96,10 @@ class TestTextMode(unittest.TestCase):
         code = convert_file(
             StringIO(SVG_TEXT_BLUE), codeoutput="codeonly", texmode="math"
         )
-        self.assertTrue(r"$a%b$" in code)
+        self.assertTrue(r"\(a%b\)" in code)
 
     def test_bad_textmode_option(self):
         """Test texmode option to attribute without texmode--attribute set"""
-        print("hello")
         code = convert_file(
             StringIO(SVG_TEXT_BLUE), texmode="attribute", texmode_attribute=None
         )

--- a/tests/testfiles/attribute_texmode.tex
+++ b/tests/testfiles/attribute_texmode.tex
@@ -63,7 +63,7 @@
 
 
   \begin{scope}[fill=black,anchor=south]
-    \node[text=black,anchor=south] (mathtext) at (1.5743, 5.2784){$\frac{a}{b}$};
+    \node[text=black,anchor=south] (mathtext) at (1.5743, 5.2784){\(\frac{a}{b}\)};
 
 
 

--- a/tests/testfiles/sub_superscript.svg
+++ b/tests/testfiles/sub_superscript.svg
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Layer_1"
+   data-name="Layer 1"
+   width="0.55186355in"
+   height="0.66757959in"
+   viewBox="0 0 39.720488 48.096801"
+   version="1.1"
+   sodipodi:docname="sub.svg"
+   inkscape:version="1.4.2 (1:1.4.2+202505120738+ebf0e940d0)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview42"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="in"
+     showgrid="false"
+     inkscape:zoom="6.6372877"
+     inkscape:cx="32.694078"
+     inkscape:cy="33.748725"
+     inkscape:window-width="1918"
+     inkscape:window-height="1173"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <defs
+     id="defs1">
+    <style
+       id="style1">
+      .cls-1 {
+        fill: #eeece2;
+      }
+
+      .cls-2 {
+        fill: #ac2424;
+      }
+
+      .cls-3 {
+        fill: #cfa33b;
+      }
+    </style>
+  </defs>
+  <text
+     id="text2"
+     x="8.0475855"
+     y="13.464231">T<tspan
+   id="tspan2"
+   style="font-size:65%;baseline-shift:sub">1<tspan
+   style="font-size:65%;baseline-shift:sub"
+   id="tspan3">2345</tspan></tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-size:10.0064px;line-height:1;font-family:'Amasis MT';-inkscape-font-specification:'Amasis MT';text-decoration-color:#000000;fill:#2d4e9c;stroke-width:0.750484;-inkscape-stroke:none;stop-color:#000000"
+     x="7.1984529"
+     y="30.487967"
+     id="text4"><tspan
+       sodipodi:role="line"
+       id="tspan4"
+       style="stroke-width:0.750484"
+       x="7.1984529"
+       y="30.487967">A<tspan
+   style="font-size:65%;baseline-shift:super"
+   id="tspan5">1<tspan
+   style="baseline-shift:super"
+   id="tspan7">2345</tspan></tspan></tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-size:10.0064px;line-height:1;font-family:'Amasis MT';-inkscape-font-specification:'Amasis MT';text-decoration-color:#000000;fill:#2d4e9c;stroke-width:0.750484;-inkscape-stroke:none;stop-color:#000000"
+     x="3.7766323"
+     y="41.577084"
+     id="text8"><tspan
+       sodipodi:role="line"
+       id="tspan8"
+       style="stroke-width:0.750484"
+       x="3.7766323"
+       y="41.577084">B<tspan
+   style="font-size:65%;baseline-shift:sub"
+   id="tspan9">123</tspan>4<tspan
+   style="font-size:65%;baseline-shift:super"
+   id="tspan15">5</tspan>6<tspan
+   style="font-size:65%;baseline-shift:sub"
+   id="tspan16">7</tspan></tspan></text>
+</svg>

--- a/tests/testfiles/sub_superscript_ascii.tex
+++ b/tests/testfiles/sub_superscript_ascii.tex
@@ -9,15 +9,15 @@
 
 \def \globalscale {1.000000}
 \begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
-  \node[anchor=south west] (text2) at (0.284, 1.2222){T 1};
+  \node[anchor=south west] (text2) at (0.284, 1.2222){T 1 2345};
 
 
 
-  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text4) at (0.254, 0.6214){A};
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text4) at (0.254, 0.6214){A 1 2345};
 
 
 
-  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text8) at (0.1333, 0.2301){B};
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text8) at (0.1333, 0.2301){B 123 4 5 6 7};
 
 
 

--- a/tests/testfiles/sub_superscript_ascii.tex
+++ b/tests/testfiles/sub_superscript_ascii.tex
@@ -1,0 +1,26 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{c2d4e9c}{RGB}{45,78,156}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
+  \node[anchor=south west] (text2) at (0.284, 1.2222){T 1};
+
+
+
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text4) at (0.254, 0.6214){A};
+
+
+
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text8) at (0.1333, 0.2301){B};
+
+
+
+
+\end{tikzpicture}
+\end{document}

--- a/tests/testfiles/sub_superscript_latex.tex
+++ b/tests/testfiles/sub_superscript_latex.tex
@@ -1,0 +1,26 @@
+
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage{tikz}
+
+\begin{document}
+\definecolor{c2d4e9c}{RGB}{45,78,156}
+
+
+\def \globalscale {1.000000}
+\begin{tikzpicture}[y=1cm, x=1cm, yscale=\globalscale,xscale=\globalscale, every node/.append style={scale=\globalscale}, inner sep=0pt, outer sep=0pt]
+  \node[anchor=south west] (text2) at (0.284, 1.2222){T\(_{1_{2345}}\)};
+
+
+
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text4) at (0.254, 0.6214){A\(^{1^{2345}}\)};
+
+
+
+  \node[text=c2d4e9c,line width=0.0265cm,anchor=south west] (text8) at (0.1333, 0.2301){B\(_{123}\)4\(^{5}\)6\(_{7}\)};
+
+
+
+
+\end{tikzpicture}
+\end{document}


### PR DESCRIPTION
# Description

Add an option to process sub/superscript to latex form from the `baseline-shift` style attribute.

Fixes #239 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested visually + output

# Checklist:

- [x] My code follows the style guidelines of this project (black/pylint)
- [x] I have updated the changelog with the corresponding changes
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
