### PR TITLE
Test skipped SVG tags

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -158,6 +158,25 @@ SVG_DEFS = r"""<?xml version="1.0" standalone="no"?>
         fill="none" stroke="blue" stroke-width=".2" />
 </svg>"""
 
+SVG_NON_RENDER_TAGS = r"""<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="10cm" height="3cm" viewBox="0 0 100 30" version="1.1"
+     xmlns="http://www.w3.org/2000/svg">
+  <desc id="hidden_desc">SHOULD_NOT_RENDER_DESC</desc>
+  <title id="hidden_title">SHOULD_NOT_RENDER_TITLE</title>
+  <metadata id="hidden_metadata">SHOULD_NOT_RENDER_METADATA</metadata>
+  <style id="hidden_style">rect { fill: red; }</style>
+  <!-- SHOULD_NOT_RENDER_COMMENT -->
+  <defs id="hidden_defs">
+    <path id="hidden_defs_path" d="M 0 0 L 10 10" />
+  </defs>
+  <symbol id="hidden_symbol">
+    <path id="hidden_symbol_path" d="M 10 0 L 0 10" />
+  </symbol>
+  <rect id="rendered_rect" x="1" y="1" width="10" height="10" />
+</svg>"""
+
 SVG_NO_HEIGHT = r"""<?xml version="1.0" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">

--- a/tests/test_svg2tikz.py
+++ b/tests/test_svg2tikz.py
@@ -18,6 +18,7 @@ from tests.common import (
     SVG_ARROW,
     SVG_TEXT_BLUE,
     SVG_DEFS,
+    SVG_NON_RENDER_TAGS,
     SVG_PAINT,
     SVG_NO_HEIGHT,
 )
@@ -122,6 +123,22 @@ class DefsTest(unittest.TestCase):
         """Test when defs are not used"""
         code = convert_file(StringIO(SVG_DEFS))
         self.assertTrue("circle" not in code)
+
+    def test_non_render_tags_are_skipped(self):
+        """Test SVG tags that should not produce TikZ output"""
+        code = convert_file(
+            StringIO(SVG_NON_RENDER_TAGS), codeoutput="codeonly", verbose=True
+        )
+        self.assertIn("rendered_rect", code)
+        self.assertNotIn("hidden_desc", code)
+        self.assertNotIn("hidden_title", code)
+        self.assertNotIn("hidden_metadata", code)
+        self.assertNotIn("hidden_style", code)
+        self.assertNotIn("SHOULD_NOT_RENDER_COMMENT", code)
+        self.assertNotIn("hidden_defs", code)
+        self.assertNotIn("hidden_defs_path", code)
+        self.assertNotIn("hidden_symbol", code)
+        self.assertNotIn("hidden_symbol_path", code)
 
 
 class MarkersTest(unittest.TestCase):


### PR DESCRIPTION
# Description

Adds a focused test fixture and unittest for SVG tags that should be skipped by the exporter. The test keeps non-rendered tags next to a visible `rect`, then checks that verbose output includes only the rendered element.

Fixes #143

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Test-only change

# How Has This Been Tested?

- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `git show --check --stat --oneline HEAD`
- [ ] `python -m unittest` (Not run locally)

# Checklist:

- [ ] My code follows the style guidelines of this project (black/pylint not run locally)
- [ ] I have updated the changelog with the corresponding changes (not applicable: test-only)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (Not run locally)